### PR TITLE
V3.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,19 @@ See the attached license file(s) for GNU GPL license.
 
 ## V3 Changes
 
+### V3.1
+
+1. Made more columns with show/hide buttons.
+2. Extended the discogs integration to get more items including publisher information (Tried to import album art, but they have block the external image links). 
+3. Technical reworking to split out code into classes, e.g. the submitted form data (reusable in form and strip creation).
+4. Lots of behind the scenes technical changes and tweaks (these should make future enhancements easier).
+5. Some little UI tweaks.
+
 ### V3.0.0
 
 1. New php driven input form (html page archived to html4form.html)
 2. Discogs.com integration (give a url for discogs and fetch data)
-3. Update indec page to use HTML 5 & bootstrap
+3. Update index page to use HTML 5 & bootstrap
 4. Customise output artist box styles, provide a box to select different artist box style (Arrow, square, hex)
 5. Show/hide columns for publisher (A lesser used function to make form cleaner)
 6. Added an option to convert all artist and/or track names to upper case
@@ -24,7 +32,6 @@ See the attached license file(s) for GNU GPL license.
 * Add/enhance fonts, try:
   * http://www.fpdf.org/en/tutorial/tuto7.htm
    * https://www.dafont.com/metal-lord.font
-* Import artwork from discogs
 * Make more options global OR label speciffic (such as hit/other markings)
 * Artist/track speciffic fonts (optional)
 * Image based backgrund for labels rather than drawing them (more options)
@@ -32,6 +39,7 @@ See the attached license file(s) for GNU GPL license.
   * More dynamic sizing
   * Ink saving (don't print empty boxes)
   * Combined image/text only labels
+* Import/export the form/label data as CSV
 
 ## V2 Changes (Stephen Rice)
 
@@ -87,4 +95,5 @@ Some other implementations, and hosting of version 2.4 and below:
 * Stephen Rice: http://www.n4yza.com/jukebox/jukebox_labels/index.html
 * GraphicStripper v 0.0.2: http://www.pinballrebel.com/archive/other/onlinenew/index.html
 * SimpleStripper v 0.0.2: http://www.pinballrebel.com/archive/other/onlinestrips/index.html
-* https://www.mikesarcade.com/arcade/titlestrips.html
+* Mikes Arcade: https://www.mikesarcade.com/arcade/titlestrips.html
+* Isolated Desert Compound (an awesome javascript form implementation, with templates for using a laser cutter): https://www.isolateddesertcompound.com/stripper/

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ See the attached license file(s) for GNU GPL license.
 
 ### V3.1.0
 
-This was pushed for release faster than expected, as the regular site scraping of discogs had broken (they addedt a javascriopt check which curl couldn't work with). Now that the API is configured, future changes on it should be easier.
+This was pushed for release faster than expected, as the regular site scraping of Discogs had broken (they added a javascriopt check which curl couldn't work with). Now that the API is configured, future changes should be easier.
 
 1. Made more columns with show/hide buttons.
-2. Changed the iscogs inteagration to use proper API
-3. Extended the discogs integration to get more items including release year information (Tried to import album art, but they have block the external image links. Tried to get publisher informatio but old scrapingmethod broke).
+2. Changed the Discogs integration to use proper API
+3. Extended the Discogs integration to get more items including release year information (Tried to import album art, but they have blocked the external image links. Tried to get publisher information but old scraping method broke).
 4. Technical reworking to split out code into classes, e.g. the submitted form data (reusable in form and strip creation).
-5. Lots of behind the scenes technical changes and tweaks (these should make future enhancements easier).
+5. Lots of behind-the-scenes technical changes and tweaks (these should make future enhancements easier).
 6. Some little UI tweaks.
 
 ### V3.0.0

--- a/README.md
+++ b/README.md
@@ -8,13 +8,14 @@ See the attached license file(s) for GNU GPL license.
 
 ## V3 Changes
 
-### V3.1
+### V3.1.0
 
 1. Made more columns with show/hide buttons.
-2. Extended the discogs integration to get more items including publisher information (Tried to import album art, but they have block the external image links). 
-3. Technical reworking to split out code into classes, e.g. the submitted form data (reusable in form and strip creation).
-4. Lots of behind the scenes technical changes and tweaks (these should make future enhancements easier).
-5. Some little UI tweaks.
+2. Changed the iscogs inteagration to use proper API
+3. Extended the discogs integration to get more items including release year information (Tried to import album art, but they have block the external image links. Tried to get publisher informatio but old scrapingmethod broke). 
+4. Technical reworking to split out code into classes, e.g. the submitted form data (reusable in form and strip creation).
+5. Lots of behind the scenes technical changes and tweaks (these should make future enhancements easier).
+6. Some little UI tweaks.
 
 ### V3.0.0
 
@@ -59,7 +60,7 @@ At time of writing, all mirrors of original seem to be down... Fortunately Steve
 > I've cobbled together a jukebox title stripper for use via the web.
 It is located at:
 > http://www.refundersrefuge.org/simplestripper/index.html
-> 
+>
 > This version doesn't let you store information (future version, I promise).
 If you can think of any features BESIDES that, please let me know. I would
 set it up to print directly onto the blank sheets, but I don't have any.
@@ -76,7 +77,7 @@ cd title cards, and I'm not adding them. The source is there, you can
 do it, or get someone else to do it for you.
 >
 > Going to start working on a standalone version. That will be Free.
-> 
+>
 > It'll be there for the forseeable future. If I move it, I'll put a
 redirector, but I don't see that happening. Feel free to grab the files and
 put it on your own sight as well, if you wish. I just had to write it,

--- a/README.md
+++ b/README.md
@@ -10,9 +10,11 @@ See the attached license file(s) for GNU GPL license.
 
 ### V3.1.0
 
+This was pushed for release faster than expected, as the regular site scraping of discogs had broken (they addedt a javascriopt check which curl couldn't work with). Now that the API is configured, future changes on it should be easier.
+
 1. Made more columns with show/hide buttons.
 2. Changed the iscogs inteagration to use proper API
-3. Extended the discogs integration to get more items including release year information (Tried to import album art, but they have block the external image links. Tried to get publisher informatio but old scrapingmethod broke). 
+3. Extended the discogs integration to get more items including release year information (Tried to import album art, but they have block the external image links. Tried to get publisher informatio but old scrapingmethod broke).
 4. Technical reworking to split out code into classes, e.g. the submitted form data (reusable in form and strip creation).
 5. Lots of behind the scenes technical changes and tweaks (these should make future enhancements easier).
 6. Some little UI tweaks.

--- a/cellz.php
+++ b/cellz.php
@@ -5,7 +5,7 @@
  * @version $Id$
  * @copyright 2003
  */
-class ZPDF extends FPDF{
+class SsFpdfExtended extends FPDF{
 
     // Extend standard cell function with one that allows scaling text within the bo (so if the text is too long, it's squished into place)
 

--- a/cellz.php
+++ b/cellz.php
@@ -6,91 +6,91 @@
  * @copyright 2003
  */
 class ZPDF extends FPDF{
-     function CellZ($w, $h = 0, $txt = '', $border = 0, $ln = 0, $align = '', $fill = 0, $link = '')
+    function CellZ($w, $h = 0, $txt = '', $border = 0, $ln = 0, $align = '', $fill = 0, $link = '')
     {
-         // Output a cell
+        // Output a cell
         $k = $this -> k;
-         if($this -> y + $h > $this -> PageBreakTrigger and !$this -> InFooter and $this -> AcceptPageBreak())
-            {
-             // Automatic page break
+        if($this -> y + $h > $this -> PageBreakTrigger and !$this -> InFooter and $this -> AcceptPageBreak())
+        {
+            // Automatic page break
             $x = $this -> x;
-             $ws = $this -> ws;
-             if($ws > 0)
+            $ws = $this -> ws;
+            if($ws > 0)
             {
-                 $this -> ws = 0;
-                 $this -> _out('0 Tw');
-                 }
-             $this -> AddPage($this -> CurOrientation);
-             $this -> x = $x;
-             if($ws > 0)
+                $this -> ws = 0;
+                $this -> _out('0 Tw');
+            }
+            $this -> AddPage($this -> CurOrientation);
+            $this -> x = $x;
+            if($ws > 0)
             {
-                 $this -> ws = $ws;
-                 $this -> _out(sprintf('%.3f Tw', $ws * $k));
-                 }
-             }
-         if($w == 0)
-             $w = $this -> w - $this -> rMargin - $this -> x;
-         $s = '';
-         if($fill == 1 or $border == 1)
+                $this -> ws = $ws;
+                $this -> _out(sprintf('%.3f Tw', $ws * $k));
+            }
+        }
+        if($w == 0)
+            $w = $this -> w - $this -> rMargin - $this -> x;
+        $s = '';
+        if($fill == 1 or $border == 1)
         {
-             if($fill == 1)
-                 $op = ($border == 1) ? 'B' : 'f';
-             else
-                 $op = 'S';
-             $s = sprintf('%.2f %.2f %.2f %.2f re %s ', $this -> x * $k, ($this -> h - $this -> y) * $k, $w * $k, - $h * $k, $op);
-             }
-         if(is_string($border))
-            {
-             $x = $this -> x;
-             $y = $this -> y;
-             if(is_int(strpos($border, 'L')))
-                 $s .= sprintf('%.2f %.2f m %.2f %.2f l S ', $x * $k, ($this -> h - $y) * $k, $x * $k, ($this -> h - ($y + $h)) * $k);
-             if(is_int(strpos($border, 'T')))
-                 $s .= sprintf('%.2f %.2f m %.2f %.2f l S ', $x * $k, ($this -> h - $y) * $k, ($x + $w) * $k, ($this -> h - $y) * $k);
-             if(is_int(strpos($border, 'R')))
-                 $s .= sprintf('%.2f %.2f m %.2f %.2f l S ', ($x + $w) * $k, ($this -> h - $y) * $k, ($x + $w) * $k, ($this -> h - ($y + $h)) * $k);
-             if(is_int(strpos($border, 'B')))
-                 $s .= sprintf('%.2f %.2f m %.2f %.2f l S ', $x * $k, ($this -> h - ($y + $h)) * $k, ($x + $w) * $k, ($this -> h - ($y + $h)) * $k);
-             }
-         if($txt != '')
+            if($fill == 1)
+                $op = ($border == 1) ? 'B' : 'f';
+            else
+                $op = 'S';
+            $s = sprintf('%.2f %.2f %.2f %.2f re %s ', $this -> x * $k, ($this -> h - $this -> y) * $k, $w * $k, - $h * $k, $op);
+        }
+        if(is_string($border))
         {
-             // CellZ: Scale
+            $x = $this -> x;
+            $y = $this -> y;
+            if(is_int(strpos($border, 'L')))
+                $s .= sprintf('%.2f %.2f m %.2f %.2f l S ', $x * $k, ($this -> h - $y) * $k, $x * $k, ($this -> h - ($y + $h)) * $k);
+            if(is_int(strpos($border, 'T')))
+                $s .= sprintf('%.2f %.2f m %.2f %.2f l S ', $x * $k, ($this -> h - $y) * $k, ($x + $w) * $k, ($this -> h - $y) * $k);
+            if(is_int(strpos($border, 'R')))
+                $s .= sprintf('%.2f %.2f m %.2f %.2f l S ', ($x + $w) * $k, ($this -> h - $y) * $k, ($x + $w) * $k, ($this -> h - ($y + $h)) * $k);
+            if(is_int(strpos($border, 'B')))
+                $s .= sprintf('%.2f %.2f m %.2f %.2f l S ', $x * $k, ($this -> h - ($y + $h)) * $k, ($x + $w) * $k, ($this -> h - ($y + $h)) * $k);
+        }
+        if($txt != '')
+        {
+            // CellZ: Scale
             $txt_scale = 100.0;
-             $str_width = $this -> GetStringWidth($txt);
-             if ($str_width > $w) $txt_scale = $w / $str_width * 100.0;
-            
-             if($align == 'R')
-                 // CellZ
+            $str_width = $this -> GetStringWidth($txt);
+            if ($str_width > $w) $txt_scale = $w / $str_width * 100.0;
+
+            if($align == 'R')
+                // CellZ
                 $dx = $w - $this -> cMargin - $this -> GetStringWidth($txt) * $txt_scale / 100.0;
-             elseif($align == 'C')
-                 // CellZ
+            elseif($align == 'C')
+                // CellZ
                 $dx = ($w - $this -> GetStringWidth($txt) * $txt_scale / 100.0) / 2;
-             else
-                 $dx = $this -> cMargin;
-             if($this -> ColorFlag)
-                 $s .= 'q ' . $this -> TextColor . ' ';
-             $txt2 = str_replace(')', '\\)', str_replace('(', '\\(', str_replace('\\', '\\\\', $txt)));
-             // CellZ
+            else
+                $dx = $this -> cMargin;
+            if($this -> ColorFlag)
+                $s .= 'q ' . $this -> TextColor . ' ';
+            $txt2 = str_replace(')', '\\)', str_replace('(', '\\(', str_replace('\\', '\\\\', $txt)));
+            // CellZ
             $s .= sprintf('BT %.2f %.2f Td %.2f Tz (%s) Tj 100 Tz ET', ($this -> x + $dx) * $k, ($this -> h - ($this -> y + .5 * $h + .3 * $this -> FontSize)) * $k, $txt_scale, $txt2);
-             if($this -> underline)
-                 $s .= ' ' . $this -> _dounderline($this -> x + $dx, $this -> y + .5 * $h + .3 * $this -> FontSize, $txt);
-             if($this -> ColorFlag)
-                 $s .= ' Q';
-             if($link)
-                 $this -> Link($this -> x + $dx, $this -> y + .5 * $h - .5 * $this -> FontSize, $this -> GetStringWidth($txt), $this -> FontSize, $link);
-             }
-         if($s)
-             $this -> _out($s);
-         $this -> lasth = $h;
-         if($ln > 0)
+            if($this -> underline)
+                $s .= ' ' . $this -> _dounderline($this -> x + $dx, $this -> y + .5 * $h + .3 * $this -> FontSize, $txt);
+            if($this -> ColorFlag)
+                $s .= ' Q';
+            if($link)
+                $this -> Link($this -> x + $dx, $this -> y + .5 * $h - .5 * $this -> FontSize, $this -> GetStringWidth($txt), $this -> FontSize, $link);
+        }
+        if($s)
+            $this -> _out($s);
+        $this -> lasth = $h;
+        if($ln > 0)
         {
-             // Go to next line
+            // Go to next line
             $this -> y += $h;
-             if($ln == 1)
-                 $this -> x = $this -> lMargin;
-             }
+            if($ln == 1)
+                $this -> x = $this -> lMargin;
+        }
         else
-             $this -> x += $w;
-         }
-     }
+            $this -> x += $w;
+    }
+}
 ?>

--- a/external_site_parser.php
+++ b/external_site_parser.php
@@ -1,0 +1,209 @@
+<?php
+
+function external_site_parser_discogs ($discogs_url, $discogs_artist_pref, $debug_output = False){
+
+    //initialise array (for any fetched data)
+    $trackArray = array();
+
+    if (isset($discogs_url) and strlen(trim($discogs_url)) > 0) { // we have a request to work with
+
+        if ($debug_output and strlen(trim($discogs_url)) > 0) {
+            echo "<h3>Discogs Data</h3>";
+            echo "<p>\n";
+            echo 'discogs_url: <a href="'.$discogs_url.'">'.$discogs_url.'</a><br>'."\n";
+            echo "discogs_artist_pref: $discogs_artist_pref <br>\n";
+            echo "</p>\n";
+
+        }
+
+        ////////////////////////////////////////////////////////////////////////////
+        // Stolen from https://www.exeideas.com/2020/07/parse-webpage-to-extract-content-using-php.html
+        // Give URL to fetch (needs to come from form)
+        ////////////////////////////////////////////////////////////////////////////
+
+        $webPageURL = $discogs_url;
+
+        ////////////////////////////////////////////////////////////////////////////
+        // Garb The WebPage Content
+        ////////////////////////////////////////////////////////////////////////////
+
+        $ch = curl_init();
+        $timeout = 5; // 5 is seconds
+        $userAgent = 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; .NET CLR 1.1.4322)';
+        curl_setopt($ch, CURLOPT_URL, $webPageURL);
+        curl_setopt($ch, CURLOPT_USERAGENT, $userAgent);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
+        curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $timeout);
+        curl_setopt($ch, CURLOPT_HEADER, 1);
+        $webPageContent = curl_exec($ch);
+        curl_close($ch);
+
+        ////////////////////////////////////////////////////////////////////////////
+        // Parse The HTML Content
+        ////////////////////////////////////////////////////////////////////////////
+        // Instantiate The DOMDocument Class
+        $htmlDom = new DOMDocument();
+        $htmlDom->validateOnParse = true;
+
+        // Parse the HTML of the page using DOMDocument::loadHTML In UTF8 Encoding
+        // @$htmlDom->loadHTML($webPageContent);
+        @$htmlDom->loadHTML(mb_convert_encoding($webPageContent, 'HTML-ENTITIES', 'UTF-8'));
+
+        ////////////////////////////////////////////////////////////////////////////
+        // Extract json encoded data from page (as discogs pages are built using javascript and manipulating the json data)
+        ////////////////////////////////////////////////////////////////////////////
+
+        // There is json data under : <script id="dsdata" type="application/json">
+        $scripts = $htmlDom->getElementsByTagName('script');
+
+        // Loop through the DOMNodeList.
+        // We can do this because the DOMNodeList object is traversable.
+        foreach ($scripts as $script) {
+
+            // Get details from entity
+            $scriptText = $script->nodeValue;
+            $scriptType = $script->getAttribute('type');
+            $scriptID   = $script->getAttribute('id');
+
+            // If the script type is empty, skip it and don't use
+            if (strlen(trim($scriptType)) == 0) {
+                continue;
+            }
+
+            // If the script id is empty, skip it and don't use
+            if (strlen(trim($scriptID)) == 0) {
+                continue;
+            }
+
+            // We only want the json data
+            if ($scriptType != 'application/json') {
+                continue;
+            }
+
+            // For the script ID dsdata
+            if ($scriptID != 'dsdata') {
+                continue;
+            }
+
+            $json_data = $scriptText;
+
+            // Once we have found the script we want, we can stop looking at scripts (there will only be one instance of it)
+            break;
+        }
+
+        ////////////////////////////////////////////////////////////////////////////
+        // Parse json data to extract what we want from it
+        ////////////////////////////////////////////////////////////////////////////
+
+        $json_data_decoded = json_decode($json_data);
+
+        // We only care about the data part, the config can be ignored
+        $json_data_decoded_data = $json_data_decoded->data;
+
+        ////////////////////////////////////////////////////////////////////////////
+        // Get release artist (if set)
+        ////////////////////////////////////////////////////////////////////////////
+
+        foreach ($json_data_decoded_data as $item) { // foreach element in $arr
+            if ($debug_output) { echo '<p>Release Info' . '</br>' . "\n"; }
+
+            $itemType = $item->__typename;
+
+            // We are interestd in Release entries
+            if ($itemType != 'Release') {
+                continue;
+            }
+
+            // var_dump($item);
+            $releaseArtistName = $item->primaryArtists[0]->displayName; // always first item in array
+
+            if ($debug_output) { echo 'Release Artist: ' . $releaseArtistName . '</br>' . "\n"; }
+
+            if ($debug_output) { echo '</p>' . "\n"; }
+
+            // The first Release item contains the artist we are intereswted in...
+            // Other releases are related items that aren't important to us
+            break;
+        }
+
+        ////////////////////////////////////////////////////////////////////////////
+        // Get track details
+        ////////////////////////////////////////////////////////////////////////////
+
+        if ($debug_output) { echo '<p>' . "\n"; }
+
+        foreach ($json_data_decoded_data as $item) { // foreach element in $arr
+
+            $itemType = $item->__typename;
+
+            // We are interestd in these
+            if ($itemType != 'Track') {
+                continue;
+            }
+
+            // var_dump($item);
+            $trackData['trackName'] = $item->title;
+            $trackData['trackPosition'] = $item->position;
+
+            //(!is_null($trackArray) && is_array($trackArray) && isset($trackArray[0]))
+            $trackData['trackArtist'] = '';
+            if (   !is_null($item->primaryArtists)
+                && is_array($item->primaryArtists)
+                && isset($item->primaryArtists[0]) ) {
+                $trackData['trackArtist'] = $item->primaryArtists[0]->displayName; // always first item in array (if exists)
+            }
+            $trackData['releaseArtist'] = $releaseArtistName;
+
+            // If this is a row of information without a track position, skip
+            if (strlen(trim($trackData['trackPosition'])) == 0) {
+                continue;
+            }
+
+            if ($discogs_artist_pref == "T") {
+                $trackData['displayArtist'] = $trackData['trackArtist'];
+            }
+
+            if ($discogs_artist_pref == "R") {
+                $trackData['displayArtist'] = $trackData['releaseArtist'];
+            }
+
+            // If ther prefference didn't work, try whateever has a value
+            if (strlen(trim($trackData['displayArtist'])) == 0) {
+                $trackData['displayArtist'] = $trackData['trackArtist'];
+            }
+
+            if (strlen(trim($trackData['displayArtist'])) == 0) {
+                $trackData['displayArtist'] = $trackData['releaseArtist'];
+            }
+
+            // strip a trailing number in brackets (for artists where there are more than one with the same name)
+            if (    (strpos($trackData['displayArtist'], '(') !== false) //str_contains() is a PHP8 new function
+                and (strpos($trackData['displayArtist'], ')') !== false)
+               ) {
+                $trackData['displayArtist'] = trim(preg_replace('/\([0-9]*\)$/i', '', $trackData['displayArtist']));
+            }
+
+            if ($debug_output) {
+                echo 'Track: ' . $trackData['trackPosition'] . ' = ' . $trackData['trackName'] . ' by '. $trackData['displayArtist'] .'(' . $trackData['trackArtist'] . ' | ' . $trackData['releaseArtist'] . ')</br>' . "\n";
+            }
+
+            $trackArray[] = $trackData;
+
+        }
+    }
+
+    if ($debug_output) { echo '</p>' . "\n"; }
+
+    if ($debug_output) {
+        echo '<h3>Variable Dumps (external_site_parser_discogs)</h3>' . "\n";
+        echo '<h4>Track Array</h4>' . "\n";
+        echo '<pre>' . "\n";
+        var_dump($trackArray);
+        echo '</pre>' . "\n";
+    }
+
+    return $trackArray;
+
+}
+
+?>

--- a/index.php
+++ b/index.php
@@ -267,37 +267,81 @@ if ($debug_output) {
         <div class="container pt-5">
         <h2>Main Form</h2>
             <p>
-                Because the Publisher information isn't a common thing for people to use, I've hidden it from the form. 
-                You can show and hide the coluns using the buttons below, the visibility of the columns doesn't impact
-                anything in them or if it's sent to the label generator.
+                Because the Publisher information isn't a common thing for people to use, I've hidden it from the form (although it's still there).
+                You can show and hide columns using the buttons below, the visibility of the columns doesn't impact
+                the values in them, or if they are sent to the label generator (everything is sent).
             </p>
             <div id="toolbar">
-                <button type="button" id="button1" class="btn btn-secondary" onclick="changeVisOn()">Show Publisher Columns</button>
-                <button type="button" id="button2" class="btn btn-secondary" onclick="changeVisOff()">Hide Publisher Columns</button>
+                <button type="button" id="button1_sh_rn" class="btn btn-secondary" onclick="changeVisOffSelected('rn')">Hide Row Number</button>
+
+                <!-- <button type="button" id="button1_sh_ta" class="btn btn-secondary" onclick="changeVisOffSelected('ta')">Hide Title A Column</button> -->
+                <!-- <button type="button" id="button1_sh_tb" class="btn btn-secondary" onclick="changeVisOffSelected('tb')">Hide Title B Column</button> -->
+
+                <!-- <button type="button" id="button1_sh_aa" class="btn btn-secondary" onclick="changeVisOffSelected('aa')">Hide Artist A Column</button> -->
+                <!-- <button type="button" id="button1_sh_ab" class="btn btn-secondary" onclick="changeVisOffSelected('ab')">Hide Artist B Column</button> -->
+
+                <button type="button" id="button1_sh_pb" class="btn btn-secondary" onclick="changeVisOnPublishers()">Show Publisher Columns</button>
+
+                <button type="button" id="button1_sh_lb" class="btn btn-secondary" onclick="changeVisOffSelected('lb')">Hide Left Bar Column</button>
+                <button type="button" id="button1_sh_rb" class="btn btn-secondary" onclick="changeVisOffSelected('rb')">Hide Right Bar Column</button>
+
+                <button type="button" id="button1_sh_im" class="btn btn-secondary" onclick="changeVisOffSelected('im')">Hide Image Column</button>
+                <button type="button" id="button1_sh_ib" class="btn btn-secondary" onclick="changeVisOffSelected('ib')">Hide Image Toggle Column</button>
             </div>
             <script>
-                function changeVisOn() {
-                    // What to do
-                    document.getElementById('p1_tr_00').style.display = 'table-cell';
-                    document.getElementById('p2_tr_00').style.display = 'table-cell';
-<?php
-                    for ($i = 1; $i <= 20; $i ++) {
-                        echo '                    document.getElementById("p1_tr_'.$i.'").style.display = "table-cell";'."\n";
-                        echo '                    document.getElementById("p2_tr_'.$i.'").style.display = "table-cell";'."\n";
+                function changeVisOffSelected(column_ref) {
+                    for (var i = 0; i <= 20; i++) {
+                        column_element = document.getElementById(column_ref + '_tr_' + i);
+                        if (column_element) {
+                            column_element.style.display = 'none';
                         }
-?>
-
-                }
-                function changeVisOff() {
-                    // What to do
-                    document.getElementById('p1_tr_00').style.display = 'none';
-                    document.getElementById('p2_tr_00').style.display = 'none';
-<?php
-                    for ($i = 1; $i <= 20; $i ++) {
-                        echo '                    document.getElementById("p1_tr_'.$i.'").style.display = "none";'."\n";
-                        echo '                    document.getElementById("p2_tr_'.$i.'").style.display = "none";'."\n";
                     }
-?>
+                    control_button_1_element = document.getElementById('button1_sh_' + column_ref);
+                    if (control_button_1_element) {
+                        old_text = control_button_1_element.textContent;
+                        new_text = old_text.replace("Hide", "Show");
+                        control_button_1_element.textContent = new_text;
+                        control_button_1_element.style.backgroundColor="green";
+                        control_button_1_element.setAttribute('onclick','changeVisOnSelected(\'' + column_ref + '\')');
+                    }
+                }
+                function changeVisOnSelected(column_ref) {
+                    for (var i = 0; i <= 20; i++) {
+                        column_element = document.getElementById(column_ref + '_tr_' + i);
+                        if (column_element) {
+                            column_element.style.display = 'table-cell';
+                        }
+                    }
+                    control_button_1_element = document.getElementById('button1_sh_' + column_ref);
+                    if (control_button_1_element) {
+                        old_text = control_button_1_element.textContent;
+                        new_text = old_text.replace("Show", "Hide");
+                        control_button_1_element.textContent = new_text;
+                        control_button_1_element.style.backgroundColor="blue";
+                        control_button_1_element.setAttribute('onclick','changeVisOffSelected(\'' + column_ref + '\')');
+                    }
+                }
+                function changeVisOnPublishers() {
+                    changeVisOnSelected('p1');
+                    changeVisOnSelected('p2');
+
+                    control_button_1_element = document.getElementById('button1_sh_pb');
+                    if (control_button_1_element) {
+                        control_button_1_element.textContent = control_button_1_element.textContent.replace("Show", "Hide");
+                        control_button_1_element.style.backgroundColor="blue";
+                        control_button_1_element.setAttribute('onclick','changeVisOffPublishers()');
+                    }
+                }
+                function changeVisOffPublishers() {
+                    changeVisOffSelected('p1');
+                    changeVisOffSelected('p2');
+
+                    control_button_1_element = document.getElementById('button1_sh_pb');
+                    if (control_button_1_element) {
+                        control_button_1_element.textContent = control_button_1_element.textContent.replace("Hide", "Show");
+                        control_button_1_element.style.backgroundColor="green";
+                        control_button_1_element.setAttribute('onclick','changeVisOnPublishers()');
+                    }
                 }
                 // Control image selection type
                 function img_switch_fn(element_id) {
@@ -368,17 +412,17 @@ if ($debug_output) {
                    >
                 <tbody>
                     <tr>
-                        <td style="vertical-align: top;"><br></td>
-                        <td style="vertical-align: top; font-weight: bold;">Title A</td>
-                        <td style="vertical-align: top; font-weight: bold;">Title B</td>
-                        <td style="vertical-align: top; font-weight: bold;">Artist A</td>
-                        <td style="vertical-align: top; font-weight: bold;">Artist B</td>
-                        <td id="p1_tr_00" style="vertical-align: top; font-weight: bold; display:none">Publisher</td>
-                        <td id="p2_tr_00" style="vertical-align: top; font-weight: bold; display:none">Publisher ID</td>
-                        <td style="vertical-align: top; font-weight: bold;">Left Bar</td>
-                        <td style="vertical-align: top; font-weight: bold;">Right Bar</td>
-                        <td style="vertical-align: top; font-weight: bold;">Image/Image URL</td>
-                        <td style="vertical-align: top; font-weight: bold;">Image/URL Toggle</td>
+                        <td id="rn_tr_0" style="vertical-align: top;"><br></td>
+                        <td id="ta_tr_0" style="vertical-align: top; font-weight: bold;">Title A</td>
+                        <td id="tb_tr_0" style="vertical-align: top; font-weight: bold;">Title B</td>
+                        <td id="aa_tr_0" style="vertical-align: top; font-weight: bold;">Artist A</td>
+                        <td id="ab_tr_0" style="vertical-align: top; font-weight: bold;">Artist B</td>
+                        <td id="p1_tr_0" style="vertical-align: top; font-weight: bold; display:none">Publisher</td>
+                        <td id="p2_tr_0" style="vertical-align: top; font-weight: bold; display:none">Publisher ID</td>
+                        <td id="lb_tr_0" style="vertical-align: top; font-weight: bold;">Left Bar</td>
+                        <td id="rb_tr_0" style="vertical-align: top; font-weight: bold;">Right Bar</td>
+                        <td id="im_tr_0" style="vertical-align: top; font-weight: bold;">Image/Image URL</td>
+                        <td id="ib_tr_0" style="vertical-align: top; font-weight: bold;">Image/URL Toggle</td>
                     </tr>
 <?php
 
@@ -447,16 +491,16 @@ for ($i = 1; $i <= 20; $i ++) {
     //$row_image = htmlentities($row_image); // Not needed
 
     echo '                    <tr>'."\n";
-    echo '                        <td text-align: right; font-weight: bold;">'.$i.'</td>'."\n";
-    echo '                        <td>                                       <input name="titlea['.$i.']"      value="'.$row_track_a.'"></td>'."\n";
-    echo '                        <td>                                       <input name="titleb['.$i.']"      value="'.$row_track_b.'"></td>'."\n";
-    echo '                        <td>                                       <input name="artista['.$i.']"     value="'.$row_artist_a.'"></td>'."\n";
-    echo '                        <td>                                       <input name="artistb['.$i.']"     value="'.$row_artist_b.'"></td>'."\n";
+    echo '                        <td id="rn_tr_'.$i.'" text-align: right; font-weight: bold;">'.$i.'</td>'."\n";
+    echo '                        <td id="ta_tr_'.$i.'">                     <input name="titlea['.$i.']"      value="'.$row_track_a.'"></td>'."\n";
+    echo '                        <td id="tb_tr_'.$i.'">                     <input name="titleb['.$i.']"      value="'.$row_track_b.'"></td>'."\n";
+    echo '                        <td id="aa_tr_'.$i.'">                     <input name="artista['.$i.']"     value="'.$row_artist_a.'"></td>'."\n";
+    echo '                        <td id="ab_tr_'.$i.'">                     <input name="artistb['.$i.']"     value="'.$row_artist_b.'"></td>'."\n";
     echo '                        <td id="p1_tr_'.$i.'" style="display:none"><input name="publisher['.$i.']"   value="'.$row_publisher.'"></td>'."\n";
     echo '                        <td id="p2_tr_'.$i.'" style="display:none"><input name="publisherid['.$i.']" value="'.$row_publisher_id.'"></td>'."\n";
-    echo '                        <td>                                       <input name="leftbar['.$i.']"     value="'.$row_left_bar.'"></td>'."\n";
-    echo '                        <td>                                       <input name="rightbar['.$i.']"    value="'.$row_right_bar.'"></td>'."\n";
-    echo '                        <td><select id="img_in_'.$i.'"                    name="imagename['.$i.']">';
+    echo '                        <td id="lb_tr_'.$i.'">                     <input name="leftbar['.$i.']"     value="'.$row_left_bar.'"></td>'."\n";
+    echo '                        <td id="rb_tr_'.$i.'">                     <input name="rightbar['.$i.']"    value="'.$row_right_bar.'"></td>'."\n";
+    echo '                        <td id="im_tr_'.$i.'"><select id="img_in_'.$i.'"  name="imagename['.$i.']">';
     echo '<option value="">None</option>';
     echo '<option value="images/wreath.jpg">Wreath</option>';
     echo '<option value="images/santa.jpg">Santa</option>';
@@ -465,7 +509,7 @@ for ($i = 1; $i <= 20; $i ++) {
     echo '<option value="images/beachboys1.jpg">Beach Boys Picture 1</option>';
     echo '</select>'."\n";
     echo '                        </td>'."\n";
-    echo '                        <td><button type="button" id="img_switch_bt_'.$i.'" class="btn btn-secondary" onclick="img_switch_fn('.$i.')">Change</button></td>'."\n";
+    echo '                        <td id="ib_tr_'.$i.'"><button type="button" id="img_switch_bt_'.$i.'" class="btn btn-secondary" onclick="img_switch_fn('.$i.')">Change</button></td>'."\n";
     echo '                    </tr>'."\n";
 
 }

--- a/index.php
+++ b/index.php
@@ -3,7 +3,7 @@
 // Setup & Config of page (main processing is set to happen in "debug output" area)
 ////////////////////////////////////////////////////////////////////////////////
 //Debugging Flag (so I can hide the ugly when not testing)
-$debug_output = true;
+$debug_output = false;
 
 require "titlestrip.php";
 require "external_site_parser.php";
@@ -130,78 +130,13 @@ if ($debug_output) {
                         Key Release history
                     </h2>
                     <p>
-                        SimpleStripper v 3 (2023) Tweaked by David Roman-Halliday<br />
+                        SimpleStripper v 3 (2023) Remodeled by David Roman-Halliday<br />
                         Modified from v 2 (02/27/2020) Extensively Modified by Stephen Rice.<br />
                         Originally written by George Howell (2001)?
                     </p>
-                    <h3>Key Changes v3</h3>
-                    <h4>
-                        v3.1
-                    </h4>
-                    <ul>
-                        <li>URL input for image (now any image can be used, made to fit by height).
-                            <ul>
-                                <li><b>Note:</b>Many images fail to load/insert because FPDF doesnn't support them (even if they are a jpg or png)</li>
-                            </ul>
-                        </li>
-                        <li>Background Changes:
-                            <ul>
-                                <li>Independant class for titlestrip manipulations and POST interaction (reusable and clean).</li>
-                                <li>Bug fixes: Resolving some bugs coming up in error log (not visible in front end).</li>
-                                <li>Discogs integration now also retrives: Release year, Publisher info, Album art URL</li>
-                                <li><b>Note:</b>RAlbumart URL fails when requested from server (protectiuon against remte image hosting and parsing their images). Big dissapointment.</li>
-                            </ul>
-                        </li>
-                    </ul>
-                    <h4>
-                        V3 Core Version
-                    </h4>
-                    <ul>
-                        <li>New php driven input form (html page archived to html4form.html).</li>
-                        <li>Discogs.com integration (give a url for discogs and fetch data).</li>
-                        <li>Update index page to use HTML 5 &amp; bootstrap.</li>
-                        <li>Customise output artist box styles, provide a box to select different artist box style (Arrow, square, hex).</li>
-                        <li>Show/hide columns for publisher (A lesser used function to make the form cleaner).</li>
-                        <li>Added an option to convert all artist and/or track names to upper case.</li>
-                        <li>Bug fix: Better handling of double quotes in the form.</li>
-                        <li>Bug fix: Stripping spaces from start/finish of artists/titles.</li>
-                    </ul>
-                    <h4>
-                        Planned Changes &amp; Suggestions for the future
-                    </h4>
-                    <ul>
-                        <li>Import data using the<a href='https://musicbrainz.org/doc/MusicBrainz_API'>MusicBrainz API</a></li>
-                        <li>Import artwork from discogs/MusicBrainz. Note: Discogs prevents the remote interaction.</li>
-                        <li>Make more options global OR label speciffic (such as hit/other markings)</li>
-                        <li>More fonts</li>
-                        <li>Artist/track speciffic fonts (optional)</li>
-                        <li>Image based backgrund for labels rather than drawing them (more options)</li>
-                        <li>Rework drawing to allow for:
-                            <ul>
-                                <li>More dynamic sizing</li>
-                                <li>Ink saving (don't print empty boxes)</li>
-                                <li>combined image/text only labels</li>
-                            </ul>
-                        </li>
-                    </ul>
-                    <h3>Key Changes v2</h3>
+                    <h2>Getting The Code &amp; Release Information</h2>
                     <p>
-                        Made by Stephen Rice
-                    </p>
-                    <ul>
-                        <li>You now can print a page without any lines on it in case you prefer to use pre printed labels.</li>
-                        <li>Updates have been done to remain compliant with the newer php server software.</li>
-                        <li>Included a updated FPDF version 1.82 software that handles printing in the zip file.</li>
-                        <li>You now have color pickers available so that you can change colors of different parts of the label. You should click on the color and pick a color and when done either click off the color or click r tab key. This allows you to have many more choices for the colors would like to print.</li>
-                        <li>The labels will now open in a new window so that all the information you have entered is still available if you want to make changes.</li>
-                    </ul>
-                    <h2>Older versions</h2>
-                    <p>
-                        By George Howell. At this time, all mirrors of original seem to be down... Fortunately Steve published the updated code (as linked above) so that open source idea of the software could continue.
-                    </p>
-                    <h2>Getting The Code</h2>
-                    <p>
-                        The code is available on github: <a href="https://github.com/d-roman-halliday/simplestripper">https://github.com/d-roman-halliday/simplestripper</a>
+                        The code, and release information (details of cahnges) are available on github: <a href="https://github.com/d-roman-halliday/simplestripper">https://github.com/d-roman-halliday/simplestripper</a>
                     </p>
                 </div>
 
@@ -430,9 +365,10 @@ if ($debug_output) {
             </script>
         <form method="post" name="record_entry">
             <h3>Discogs</h3>
-            <p>Get data from discogs and append to strip information. This will append to the rows below, note for now only artist and track names will be loaded and refreshed.</p>
+            <p>Get data from discogs and append to strip information. This will append to the rows below. For now only artist and track names (and release year if selected) will be loaded and refreshed.</p>
             <p>
-                <input type="text"  name="external_site_url" id="external_site_url_id" ><br>
+                <label for="external_site_url_id">Discogs URL:</label>
+                <input type="text"  id="external_site_url_id" name="external_site_url" id="external_site_url_id" ><br>
             </p>
             <h4>
                 External Site Configurations
@@ -614,9 +550,9 @@ for ($i = 1; $i <= 20; $i ++) {
             <h4>
                 Font
             </h4>
-            <input id="font_01" type="radio" name="titlefont" value="Times"                    ><label for="font_01">Times</label><br>
-            <input id="font_02" type="radio" name="titlefont" value="Helvetica"                ><label for="font_02">Helvetica</label><br>
-            <input id="font_03" type="radio" name="titlefont" value="Courier" checked="checked"><label for="font_03">Courier</label>
+            <input id="font_01" type="radio" name="titlefont" value="Times"                      ><label for="font_01">Times</label><br>
+            <input id="font_02" type="radio" name="titlefont" value="Helvetica" checked="checked"><label for="font_02">Helvetica</label><br>
+            <input id="font_03" type="radio" name="titlefont" value="Courier"                    ><label for="font_03">Courier</label>
             <h4>
                 Font Color
             </h4>

--- a/index.php
+++ b/index.php
@@ -6,6 +6,7 @@
 $debug_output = true;
 
 require "titlestrip.php";
+require "external_site_parser.php";
 
 ?>
 <!doctype html>
@@ -204,285 +205,60 @@ if ($debug_output) {
                     </p>
 <?php
 
-////////////////////////////////////////////////////////////////////////////////
-// Main Processing
-////////////////////////////////////////////////////////////////////////////////
+                    ////////////////////////////////////////////////////////////////////////////
+                    // Parse any existing titlestrip information
+                    ////////////////////////////////////////////////////////////////////////////
+                    $ts_manager = new titlestrip_manager;
 
-//initialise array (for any fetched data)
-$trackArray = array();
-//Default values
-$t_checked = 'checked="checked"';
-$r_checked = '';
+                    foreach($ts_manager->titlestrips as $titlestrip)
+                    {
+                        $combined_artist = $titlestrip->get_combined_artist();
+                        echo "titlestrip_artist: $titlestrip->track_a / - $combined_artist<br>\n";
+                    }
 
-/*
-**************************************************************************
-*/
-// POST data (discogs)
-/*
-**************************************************************************
-*/
+                    ////////////////////////////////////////////////////////////
+                    // Request data from External URL (discogs)
+                    ////////////////////////////////////////////////////////////
 
-//Discogs data
-if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $discogs_url = trim(stripslashes($_POST['discogs_url']));
-    $discogs_artist_pref = $_POST['discogs_artist_pref'];
-}
+                    //Initialise array (for any fetched data)
+                    $trackArray = array();
 
-if (isset($discogs_url) and strlen(trim($discogs_url)) > 0) { // we have a request to work with
+                    //Default values (preference for track/release artist)
+                    $t_checked = 'checked="checked"';
+                    $r_checked = '';
 
-    if ($debug_output and strlen(trim($discogs_url)) > 0) {
-        echo "<h3>Discogs Data</h3>";
-        echo "<p>\n";
-        echo 'discogs_url: <a href="'.$discogs_url.'">'.$discogs_url.'</a><br>'."\n";
-        echo "discogs_artist_pref: $discogs_artist_pref <br>\n";
-        echo "</p>\n";
+                    //Get data from form (if submitted)
+                    if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+                        $discogs_url = trim(stripslashes($_POST['discogs_url']));
+                        $discogs_artist_pref = trim(stripslashes($_POST['discogs_artist_pref']));
+                    }
 
-    }
+                    //Get array of data from URL
+                    if (isset($discogs_url) and strlen(trim($discogs_url)) > 0) { // we have a request to work with
+                        $trackArray = external_site_parser_discogs($discogs_url,$discogs_artist_pref,$debug_output);
+                    }
 
-    if ($discogs_artist_pref == "T") {
-        $t_checked = 'checked="checked"';
-        $r_checked = '';
-    } else {
-        $t_checked = '';
-        $r_checked = 'checked="checked"';
-    }
+                    //Change settings for dislay of form (preference for track/release artist)
+                    if (isset($discogs_artist_pref) and $discogs_artist_pref == "R") {
+                        $t_checked = '';
+                        $r_checked = 'checked="checked"';
+                    }
 
-/*
-**************************************************************************
-*/
-// POST data (main form)
-/*
-**************************************************************************
-*/
-    $ts_manager = new titlestrip_manager;
+                    ////////////////////////////////////////////////////////////
+                    // Request data from External URL (discogs)
+                    ////////////////////////////////////////////////////////////
 
-    foreach($ts_manager->titlestrips as $titlestrip)
-    {
-        $combined_artist = $titlestrip->get_combined_artist();
-        echo "titlestrip_artist: $titlestrip->track_a / - $combined_artist<br>\n";
-    }
-
-/*
-**************************************************************************
-*/
-// Stolen from https://www.exeideas.com/2020/07/parse-webpage-to-extract-content-using-php.html
-// Give URL to fetch (needs to come from form)
-/*
-**************************************************************************
-*/
-
-    $webPageURL = $discogs_url;
-
-/*
-**************************************************************************
-*/
-// Garb The WebPage Content
-/*
-**************************************************************************
-*/
-
-    $ch = curl_init();
-    $timeout = 5; // 5 is seconds
-    $userAgent = 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; .NET CLR 1.1.4322)';
-    curl_setopt($ch, CURLOPT_URL, $webPageURL);
-    curl_setopt($ch, CURLOPT_USERAGENT, $userAgent);
-    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
-    curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $timeout);
-    curl_setopt($ch, CURLOPT_HEADER, 1);
-    $webPageContent = curl_exec($ch);
-    curl_close($ch);
-
-/*
-**************************************************************************
-*/
-// Parse The HTML Content
-/*
-**************************************************************************
-*/
-    // Instantiate The DOMDocument Class
-    $htmlDom = new DOMDocument();
-    $htmlDom->validateOnParse = true;
-
-    // Parse the HTML of the page using DOMDocument::loadHTML In UTF8 Encoding
-    // @$htmlDom->loadHTML($webPageContent);
-    @$htmlDom->loadHTML(mb_convert_encoding($webPageContent, 'HTML-ENTITIES', 'UTF-8'));
-
-/*
-**************************************************************************
-*/
-// Extract json encoded data from page (as discogs pages are built using javascript and manipulating the json data)
-/*
-**************************************************************************
-*/
-
-    // There is json data under : <script id="dsdata" type="application/json">
-    $scripts = $htmlDom->getElementsByTagName('script');
-
-    // Loop through the DOMNodeList.
-    // We can do this because the DOMNodeList object is traversable.
-    foreach ($scripts as $script) {
-
-        // Get details from entity
-        $scriptText = $script->nodeValue;
-        $scriptType = $script->getAttribute('type');
-        $scriptID   = $script->getAttribute('id');
-
-        // If the script type is empty, skip it and don't use
-        if (strlen(trim($scriptType)) == 0) {
-            continue;
-        }
-
-        // If the script id is empty, skip it and don't use
-        if (strlen(trim($scriptID)) == 0) {
-            continue;
-        }
-
-        // We only want the json data
-        if ($scriptType != 'application/json') {
-            continue;
-        }
-
-        // For the script ID dsdata
-        if ($scriptID != 'dsdata') {
-            continue;
-        }
-
-        $json_data = $scriptText;
-
-        // Once we have found the script we want, we can stop looking at scripts (there will only be one instance of it)
-        break;
-    }
-
-/*
-**************************************************************************
-*/
-// Parse json data to extract what we want from it
-/*
-**************************************************************************
-*/
-
-    $json_data_decoded = json_decode($json_data);
-
-    // We only care about the data part, the config can be ignored
-    $json_data_decoded_data = $json_data_decoded->data;
-
-/*
-**************************************************************************
-*/
-// Get release artist (if set)
-/*
-**************************************************************************
-*/
-
-
-    foreach ($json_data_decoded_data as $item) { // foreach element in $arr
-        if ($debug_output) { echo '<p>Release Info' . '</br>' . "\n"; }
-
-        $itemType = $item->__typename;
-
-        // We are interestd in Release entries
-        if ($itemType != 'Release') {
-            continue;
-        }
-
-        // var_dump($item);
-        $releaseArtistName = $item->primaryArtists[0]->displayName; // always first item in array
-
-        if ($debug_output) { echo 'Release Artist: ' . $releaseArtistName . '</br>' . "\n"; }
-
-        if ($debug_output) { echo '</p>' . "\n"; }
-
-        // The first Release item contains the artist we are intereswted in...
-        // Other releases are related items that aren't important to us
-        break;
-    }
-
-/*
-**************************************************************************
-*/
-// Get track details
-/*
-**************************************************************************
-*/
-
-    if ($debug_output) { echo '<p>' . "\n"; }
-
-    foreach ($json_data_decoded_data as $item) { // foreach element in $arr
-
-        $itemType = $item->__typename;
-
-        // We are interestd in these
-        if ($itemType != 'Track') {
-            continue;
-        }
-
-        // var_dump($item);
-        $trackData['trackName'] = $item->title;
-        $trackData['trackPosition'] = $item->position;
-
-        //(!is_null($trackArray) && is_array($trackArray) && isset($trackArray[0]))
-        $trackData['trackArtist'] = '';
-        if (   !is_null($item->primaryArtists)
-            && is_array($item->primaryArtists)
-            && isset($item->primaryArtists[0]) ) {
-            $trackData['trackArtist'] = $item->primaryArtists[0]->displayName; // always first item in array (if exists)
-        }
-        $trackData['releaseArtist'] = $releaseArtistName;
-
-        // If this is a row of information without a track position, skip
-        if (strlen(trim($trackData['trackPosition'])) == 0) {
-            continue;
-        }
-
-        if ($discogs_artist_pref == "T") {
-            $trackData['displayArtist'] = $trackData['trackArtist'];
-        }
-
-        if ($discogs_artist_pref == "R") {
-            $trackData['displayArtist'] = $trackData['releaseArtist'];
-        }
-
-        // If ther prefference didn't work, try whateever has a value
-        if (strlen(trim($trackData['displayArtist'])) == 0) {
-            $trackData['displayArtist'] = $trackData['trackArtist'];
-        }
-
-        if (strlen(trim($trackData['displayArtist'])) == 0) {
-            $trackData['displayArtist'] = $trackData['releaseArtist'];
-        }
-
-        // strip a trailing number in brackets (for artists where there are more than one with the same name)
-        if (    (strpos($trackData['displayArtist'], '(') !== false) //str_contains() is a PHP8 new function
-            and (strpos($trackData['displayArtist'], ')') !== false)
-           ) {
-            $trackData['displayArtist'] = trim(preg_replace('/\([0-9]*\)$/i', '', $trackData['displayArtist']));
-        }
-
-        if ($debug_output) {
-            echo 'Track: ' . $trackData['trackPosition'] . ' = ' . $trackData['trackName'] . ' by '. $trackData['displayArtist'] .'(' . $trackData['trackArtist'] . ' | ' . $trackData['releaseArtist'] . ')</br>' . "\n";
-        }
-
-        $trackArray[] = $trackData;
-
-    }
-}
-
-if ($debug_output) { echo '</p>' . "\n"; }
-
-if ($debug_output) {
-    echo '<h3>Variable Dumps</h3>' . "\n";
-    echo '<h4>Track Array</h4>' . "\n";
-    echo '<pre>' . "\n";
-    var_dump($trackArray);
-    echo '</pre>' . "\n";
-    echo '<h4>Title Strips Manager</h4>' . "\n";
-    echo '<pre>' . "\n";
-    var_dump($ts_manager);
-    echo '</pre>' . "\n";
-
-}
-
-
+                    if ($debug_output) {
+                        echo '<h3>Variable Dumps (main)</h3>' . "\n";
+                        echo '<h4>Track Array</h4>' . "\n";
+                        echo '<pre>' . "\n";
+                        var_dump($trackArray);
+                        echo '</pre>' . "\n";
+                        echo '<h4>Title Strips Manager</h4>' . "\n";
+                        echo '<pre>' . "\n";
+                        var_dump($ts_manager);
+                        echo '</pre>' . "\n";
+                    }
 ?>
                 </div>
             </div>

--- a/index.php
+++ b/index.php
@@ -3,7 +3,7 @@
 // Setup & Config of page (main processing is set to happen in "debug output" area)
 ////////////////////////////////////////////////////////////////////////////////
 //Debugging Flag (so I can hide the ugly when not testing)
-$debug_output = false;
+$debug_output = true;
 
 require "titlestrip.php";
 require "external_site_parser.php";
@@ -216,14 +216,50 @@ if ($debug_output) {
                     ////////////////////////////////////////////////////////////////////////////
                     $ts_manager = new titlestrip_manager;
 
+                    ////////////////////////////////////////////////////////////////////////////
+                    // Parse any existing form information (for external site parsing)
+                    ////////////////////////////////////////////////////////////////////////////
+                    $ex_manager = new external_site_manager;
+
+                    ////////////////////////////////////////////////////////////
+                    // Form default values management
+                    ////////////////////////////////////////////////////////////
+
+                    // External Site Configuration
+                    $external_site_release_artist_preference_checked_t = 'checked="checked"';
+                    $external_site_release_artist_preference_checked_r = '';
+                    if (isset($discogs_artist_pref) and $discogs_artist_pref == "R") {
+                        $external_site_release_artist_preference_checked_t = '';
+                        $external_site_release_artist_preference_checked_r = 'checked="checked"';
+                    }
+
+                    $external_site_year_preference_checked_n = '';
+                    if ($ex_manager->external_site_year_preference === 'N') {$external_site_year_preference_checked_n  = 'checked="checked"';}
+                    $external_site_year_preference_checked_l = '';
+                    if ($ex_manager->external_site_year_preference === 'L') {$external_site_year_preference_checked_l  = 'checked="checked"';}
+                    $external_site_year_preference_checked_r = '';
+                    if ($ex_manager->external_site_year_preference === 'R') {$external_site_year_preference_checked_r  = 'checked="checked"';}
+
+                    $external_site_LabelName_include_checked = '';
+                    if ($ex_manager->external_site_LabelName_include) {$external_site_LabelName_include_checked  = 'checked="checked"';}
+
+                    $external_site_CatalogNumber_include_checked = '';
+                    if ($ex_manager->external_site_CatalogNumber_include) {$external_site_CatalogNumber_include_checked  = 'checked="checked"';}
+
+                    // Title Strip Configuration
+                    $artist_upper_id_checked = '';
+                    if ($ts_manager->artist_upper_case) {$artist_upper_id_checked = 'checked="checked"';}
+
+                    $track_upper_id_checked = '';
+                    if ($ts_manager->track_upper_case) {$track_upper_id_checked  = 'checked="checked"';}
+
+
                     ////////////////////////////////////////////////////////////
                     // Request data from External URL (discogs)
                     ////////////////////////////////////////////////////////////
-
-                    //Get data from form (if submitted)
                     if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-                        $discogs_url = trim(stripslashes($_POST['discogs_url']));
-                        $discogs_artist_pref = trim(stripslashes($_POST['discogs_artist_pref']));
+                        $discogs_url = $ex_manager->external_site_url;
+                        $discogs_artist_pref = $ex_manager->external_site_release_artist_preference;
                     }
 
                     //Initialise array (for any fetched data)
@@ -232,16 +268,6 @@ if ($debug_output) {
                     //Get array of data from URL
                     if (isset($discogs_url) and strlen(trim($discogs_url)) > 0) { // we have a request to work with
                         $trackArray = external_site_parser_discogs($discogs_url,$discogs_artist_pref,$debug_output);
-                    }
-
-                    //Default values (preference for track/release artist)
-                    $t_checked = 'checked="checked"';
-                    $r_checked = '';
-
-                    //Change settings for dislay of form (preference for track/release artist)
-                    if (isset($discogs_artist_pref) and $discogs_artist_pref == "R") {
-                        $t_checked = '';
-                        $r_checked = 'checked="checked"';
                     }
 
                     ////////////////////////////////////////////////////////////
@@ -253,6 +279,10 @@ if ($debug_output) {
                         echo '<h4>Track Array</h4>' . "\n";
                         echo '<pre>' . "\n";
                         var_dump($trackArray);
+                        echo '</pre>' . "\n";
+                        echo '<h4>External Site Manager</h4>' . "\n";
+                        echo '<pre>' . "\n";
+                        var_dump($ex_manager);
                         echo '</pre>' . "\n";
                         echo '<h4>Title Strips Manager</h4>' . "\n";
                         echo '<pre>' . "\n";
@@ -400,9 +430,34 @@ if ($debug_output) {
             <h3>Discogs</h3>
             <p>Get data from discogs and append to strip information. This will append to the rows below, note for now only artist and track names will be loaded and refreshed.</p>
             <p>
-                <input type="text"  name="discogs_url" id="discogs_url" ><br>
-                <input type="radio" name="discogs_artist_pref" value="R" <?php echo $r_checked; ?>>Prefer Release Artist<br>
-                <input type="radio" name="discogs_artist_pref" value="T" <?php echo $t_checked; ?>>Prefer Track Artist<br>
+                <input type="text"  name="external_site_url" id="external_site_url_id" ><br>
+            </p>
+            <h4>
+                External Site Configurations
+            </h4>
+            <p>
+                <label for="external_site_release_artist_preference_id_r">Prefer Release Artist</label>
+                <input type="radio" id="external_site_release_artist_preference_id_r" name="external_site_release_artist_preference" value="R" <?php echo $external_site_release_artist_preference_checked_r; ?>><br>
+                <label for="external_site_release_artist_preference_id_t">Prefer Track Artist</label>
+                <input type="radio" id="external_site_release_artist_preference_id_t" name="external_site_release_artist_preference" value="T" <?php echo $external_site_release_artist_preference_checked_t; ?>><br>
+            </p>
+            <p>
+                <label for="external_site_year_preference_id_n">Don't include relese year</label>
+                <input type="radio" id="external_site_year_preference_id_n" name="external_site_year_preference" value="N" <?php echo $external_site_year_preference_checked_n; ?>><br>
+                <label for="external_site_year_preference_id_l">Release Year in Left Bar</label>
+                <input type="radio" id="external_site_year_preference_id_l" name="external_site_year_preference" value="L" <?php echo $external_site_year_preference_checked_l; ?>><br>
+                <label for="external_site_year_preference_id_r">Release Year in Right Bar</label>
+                <input type="radio" id="external_site_year_preference_id_r" name="external_site_year_preference" value="R" <?php echo $external_site_year_preference_checked_r; ?>><br>
+
+            </p>
+            <p>
+                <label for="external_site_LabelName_include_id">Include Label Name</label>
+                <input type="checkbox" id="external_site_LabelName_include_id"     name="external_site_LabelName_include"     value="external_site_LabelName_include_t"     <?php echo $external_site_LabelName_include_checked; ?>>
+                <br>
+                <label for="external_site_CatalogNumber_include_id">Include Catalog Number</label>
+                <input type="checkbox" id="external_site_CatalogNumber_include_id" name="external_site_CatalogNumber_include" value="external_site_CatalogNumber_include_t" <?php echo $external_site_CatalogNumber_include_checked; ?>>
+            </p>
+            <p>
                 <input type="submit" value="Submit">
             </p>
             <h3>Strip Details</h3>
@@ -600,10 +655,10 @@ for ($i = 1; $i <= 20; $i ++) {
             </h4>
             <p>
                 <label for="artist_upper_id">Convert all artist names to upper case</label>
-                <input type="checkbox" id="artist_upper_id" name="artist_upper" value="artist_upper_case">
+                <input type="checkbox" id="artist_upper_id" name="artist_upper" value="artist_upper_case" <?php echo $artist_upper_id_checked ?>>
                 <br>
                 <label for="track_upper_id">Convert all track names to upper case</label>
-                <input type="checkbox" id="track_upper_id" name="track_upper" value="track_upper_case">
+                <input type="checkbox" id="track_upper_id"  name="track_upper"  value="track_upper_case"  <?php echo $track_upper_id_checked ?>>
             </p>
             <p>
                 <!--  Reset doesn't work if form is already populated at start, javascript could help -->

--- a/index.php
+++ b/index.php
@@ -240,11 +240,11 @@ if ($debug_output) {
                     $external_site_year_preference_checked_r = '';
                     if ($ex_manager->external_site_year_preference === 'R') {$external_site_year_preference_checked_r  = 'checked="checked"';}
 
-                    $external_site_LabelName_include_checked = '';
-                    if ($ex_manager->external_site_LabelName_include) {$external_site_LabelName_include_checked  = 'checked="checked"';}
+                    $external_site_LabelName_include_checked = ''; // Not in basic API
+                    //if ($ex_manager->external_site_LabelName_include) {$external_site_LabelName_include_checked  = 'checked="checked"';}
 
-                    $external_site_CatalogNumber_include_checked = '';
-                    if ($ex_manager->external_site_CatalogNumber_include) {$external_site_CatalogNumber_include_checked  = 'checked="checked"';}
+                    $external_site_CatalogNumber_include_checked = ''; // Not in basic API
+                    //if ($ex_manager->external_site_CatalogNumber_include) {$external_site_CatalogNumber_include_checked  = 'checked="checked"';}
 
                     // Title Strip Configuration
                     $artist_upper_id_checked = '';
@@ -267,7 +267,9 @@ if ($debug_output) {
 
                     //Get array of data from URL
                     if (isset($discogs_url) and strlen(trim($discogs_url)) > 0) { // we have a request to work with
-                        $trackArray = external_site_parser_discogs($discogs_url,$discogs_artist_pref,$debug_output);
+                        // New: Using API from discogs
+                        $api_client = new discogs_api_client;
+                        $trackArray = $api_client->get_track_data_from_url($discogs_url,$discogs_artist_pref,$debug_output);
                     }
 
                     ////////////////////////////////////////////////////////////
@@ -442,7 +444,7 @@ if ($debug_output) {
                 <input type="radio" id="external_site_release_artist_preference_id_t" name="external_site_release_artist_preference" value="T" <?php echo $external_site_release_artist_preference_checked_t; ?>><br>
             </p>
             <p>
-                <label for="external_site_year_preference_id_n">Don't include relese year</label>
+                <label for="external_site_year_preference_id_n">Don't include Release Year</label>
                 <input type="radio" id="external_site_year_preference_id_n" name="external_site_year_preference" value="N" <?php echo $external_site_year_preference_checked_n; ?>><br>
                 <label for="external_site_year_preference_id_l">Release Year in Left Bar</label>
                 <input type="radio" id="external_site_year_preference_id_l" name="external_site_year_preference" value="L" <?php echo $external_site_year_preference_checked_l; ?>><br>
@@ -451,11 +453,14 @@ if ($debug_output) {
 
             </p>
             <p>
+                <!-- Not available in basic API -->
+<!--
                 <label for="external_site_LabelName_include_id">Include Label Name</label>
                 <input type="checkbox" id="external_site_LabelName_include_id"     name="external_site_LabelName_include"     value="external_site_LabelName_include_t"     <?php echo $external_site_LabelName_include_checked; ?>>
                 <br>
                 <label for="external_site_CatalogNumber_include_id">Include Catalog Number</label>
                 <input type="checkbox" id="external_site_CatalogNumber_include_id" name="external_site_CatalogNumber_include" value="external_site_CatalogNumber_include_t" <?php echo $external_site_CatalogNumber_include_checked; ?>>
+-->
             </p>
             <p>
                 <input type="submit" value="Submit">
@@ -515,12 +520,20 @@ for ($i = 1; $i <= 20; $i ++) {
 
     } else {
 
+        // Artist/Trak A (and all other data from the release)
         if (!is_null($trackArray) && is_array($trackArray) && isset($trackArray[0])) {
             $trackData = array_shift($trackArray);
             $row_track_a  = $trackData['trackName'];
             $row_artist_a = $trackData['displayArtist'];
+
+            // Release Year
+            if(!is_null($trackData['releaseYear'])) {
+                if ($ex_manager->external_site_year_preference === 'L') { $row_left_bar = $trackData['releaseYear']; }
+                if ($ex_manager->external_site_year_preference === 'R') { $row_right_bar = $trackData['releaseYear']; }
+            }
         }
 
+        // Artist/Trak B
         if (!is_null($trackArray) && is_array($trackArray) && isset($trackArray[0])) {
             $trackData = array_shift($trackArray);
             $row_track_b  = $trackData['trackName'];
@@ -531,6 +544,7 @@ for ($i = 1; $i <= 20; $i ++) {
         if ($row_artist_a == $row_artist_b) {
             $row_artist_b = '';
         }
+
     }
 
     //Clean up HTML display characters...

--- a/index.php
+++ b/index.php
@@ -134,21 +134,37 @@ if ($debug_output) {
                         Originally written by George Howell (2001)?
                     </p>
                     <h3>Key Changes v3</h3>
+                    <h4>
+                        v3.1
+                    </h4>
+                    <ul>
+                        <li>URL input for image (now any image can be used, made to fit by height).</li>
+                        <li>Background Changes:
+                            <ul>
+                                <li>Independant class for titlestrip manipulations and POST interaction (reusable and clean).</li>
+                                <li>Bug fixes: Resolving some bugs coming up in error log (not visible in front end).</li>
+                            </ul>
+                        </li>
+                    </ul>
+                    <h4>
+                        V3 Core Version
+                    </h4>
                     <ul>
                         <li>New php driven input form (html page archived to html4form.html).</li>
                         <li>Discogs.com integration (give a url for discogs and fetch data).</li>
-                        <li>Update indec page to use HTML 5 &amp; bootstrap.</li>
+                        <li>Update index page to use HTML 5 &amp; bootstrap.</li>
                         <li>Customise output artist box styles, provide a box to select different artist box style (Arrow, square, hex).</li>
-                        <li>Show/hide columns for publisher (A lesser used function to make form cleaner).</li>
+                        <li>Show/hide columns for publisher (A lesser used function to make the form cleaner).</li>
                         <li>Added an option to convert all artist and/or track names to upper case.</li>
                         <li>Bug fix: Better handling of double quotes in the form.</li>
                         <li>Bug fix: Stripping spaces from start/finish of artists/titles.</li>
                     </ul>
                     <h4>
-                        Planned Changes &amp; Suggestions for v3.1 and onwards
+                        Planned Changes &amp; Suggestions for the future
                     </h4>
                     <ul>
-                        <li>Import artwork from discogs</li>
+                        <li>Import data using the<a href='https://musicbrainz.org/doc/MusicBrainz_API'>MusicBrainz API</a></li>
+                        <li>Import artwork from discogs/MusicBrainz</li>
                         <li>Make more options global OR label speciffic (such as hit/other markings)</li>
                         <li>More fonts</li>
                         <li>Artist/track speciffic fonts (optional)</li>
@@ -413,7 +429,7 @@ if (isset($discogs_url) and strlen(trim($discogs_url)) > 0) { // we have a reque
         }
         $trackData['releaseArtist'] = $releaseArtistName;
 
-        // If this is a row of information without a trqck position, skip
+        // If this is a row of information without a track position, skip
         if (strlen(trim($trackData['trackPosition'])) == 0) {
             continue;
         }
@@ -435,11 +451,11 @@ if (isset($discogs_url) and strlen(trim($discogs_url)) > 0) { // we have a reque
             $trackData['displayArtist'] = $trackData['releaseArtist'];
         }
 
-        // strip a trining number in brackets (for artists where there are more than one with the same name)
+        // strip a trailing number in brackets (for artists where there are more than one with the same name)
         if (    (strpos($trackData['displayArtist'], '(') !== false) //str_contains() is a PHP8 new function
             and (strpos($trackData['displayArtist'], ')') !== false)
            ) {
-            $trackData['displayArtist'] = preg_replace('/\([0-9]*\)$/i', '', $trackData['displayArtist']);
+            $trackData['displayArtist'] = trim(preg_replace('/\([0-9]*\)$/i', '', $trackData['displayArtist']));
         }
 
         if ($debug_output) {
@@ -452,6 +468,20 @@ if (isset($discogs_url) and strlen(trim($discogs_url)) > 0) { // we have a reque
 }
 
 if ($debug_output) { echo '</p>' . "\n"; }
+
+if ($debug_output) {
+    echo '<h3>Variable Dumps</h3>' . "\n";
+    echo '<h4>Track Array</h4>' . "\n";
+    echo '<pre>' . "\n";
+    var_dump($trackArray);
+    echo '</pre>' . "\n";
+    echo '<h4>Title Strips Manager</h4>' . "\n";
+    echo '<pre>' . "\n";
+    var_dump($ts_manager);
+    echo '</pre>' . "\n";
+
+}
+
 
 ?>
                 </div>

--- a/index.php
+++ b/index.php
@@ -3,7 +3,7 @@
 // Setup & Config of page (main processing is set to happen in "debug output" area)
 ////////////////////////////////////////////////////////////////////////////////
 //Debugging Flag (so I can hide the ugly when not testing)
-$debug_output = true;
+$debug_output = false;
 
 require "titlestrip.php";
 require "external_site_parser.php";
@@ -139,11 +139,17 @@ if ($debug_output) {
                         v3.1
                     </h4>
                     <ul>
-                        <li>URL input for image (now any image can be used, made to fit by height).</li>
+                        <li>URL input for image (now any image can be used, made to fit by height).
+                            <ul>
+                                <li><b>Note:</b>Many images fail to load/insert because FPDF doesnn't support them (even if they are a jpg or png)</li>
+                            </ul>
+                        </li>
                         <li>Background Changes:
                             <ul>
                                 <li>Independant class for titlestrip manipulations and POST interaction (reusable and clean).</li>
                                 <li>Bug fixes: Resolving some bugs coming up in error log (not visible in front end).</li>
+                                <li>Discogs integration now also retrives: Release year, Publisher info, Album art URL</li>
+                                <li><b>Note:</b>RAlbumart URL fails when requested from server (protectiuon against remte image hosting and parsing their images). Big dissapointment.</li>
                             </ul>
                         </li>
                     </ul>
@@ -165,7 +171,7 @@ if ($debug_output) {
                     </h4>
                     <ul>
                         <li>Import data using the<a href='https://musicbrainz.org/doc/MusicBrainz_API'>MusicBrainz API</a></li>
-                        <li>Import artwork from discogs/MusicBrainz</li>
+                        <li>Import artwork from discogs/MusicBrainz. Note: Discogs prevents the remote interaction.</li>
                         <li>Make more options global OR label speciffic (such as hit/other markings)</li>
                         <li>More fonts</li>
                         <li>Artist/track speciffic fonts (optional)</li>
@@ -210,22 +216,9 @@ if ($debug_output) {
                     ////////////////////////////////////////////////////////////////////////////
                     $ts_manager = new titlestrip_manager;
 
-                    foreach($ts_manager->titlestrips as $titlestrip)
-                    {
-                        $combined_artist = $titlestrip->get_combined_artist();
-                        echo "titlestrip_artist: $titlestrip->track_a / - $combined_artist<br>\n";
-                    }
-
                     ////////////////////////////////////////////////////////////
                     // Request data from External URL (discogs)
                     ////////////////////////////////////////////////////////////
-
-                    //Initialise array (for any fetched data)
-                    $trackArray = array();
-
-                    //Default values (preference for track/release artist)
-                    $t_checked = 'checked="checked"';
-                    $r_checked = '';
 
                     //Get data from form (if submitted)
                     if ($_SERVER['REQUEST_METHOD'] === 'POST') {
@@ -233,10 +226,17 @@ if ($debug_output) {
                         $discogs_artist_pref = trim(stripslashes($_POST['discogs_artist_pref']));
                     }
 
+                    //Initialise array (for any fetched data)
+                    $trackArray = array();
+
                     //Get array of data from URL
                     if (isset($discogs_url) and strlen(trim($discogs_url)) > 0) { // we have a request to work with
                         $trackArray = external_site_parser_discogs($discogs_url,$discogs_artist_pref,$debug_output);
                     }
+
+                    //Default values (preference for track/release artist)
+                    $t_checked = 'checked="checked"';
+                    $r_checked = '';
 
                     //Change settings for dislay of form (preference for track/release artist)
                     if (isset($discogs_artist_pref) and $discogs_artist_pref == "R") {
@@ -245,7 +245,7 @@ if ($debug_output) {
                     }
 
                     ////////////////////////////////////////////////////////////
-                    // Request data from External URL (discogs)
+                    // Dump Variables
                     ////////////////////////////////////////////////////////////
 
                     if ($debug_output) {
@@ -395,7 +395,10 @@ for ($i = 1; $i <= 20; $i ++) {
     $row_image = '';
 
     $row_already_populated = False;
-    if (isset($ts_manager)){
+    if (   isset($ts_manager)
+        && is_array($ts_manager->titlestrips)
+        && isset($ts_manager->titlestrips[$i])
+       ){
         $row_already_populated = $ts_manager->titlestrips[$i]->has_set_values();
     }
 

--- a/printstrips.php
+++ b/printstrips.php
@@ -27,44 +27,6 @@ $smallfontsize = "9";
 // Get variables from POST and populate titlestrip objects
 $ts_manager = new titlestrip_manager;
 
-// Non array values
-$titlesize = $_POST['titlesize'];
-$titlefont = $_POST['titlefont'];
-$framecolor = $_POST['framecolor'];
-$background = $_POST['background'];
-$backgroundcolor = $_POST['backgroundcolor'];
-$artistbackgroundcolor = $_POST['artistbackgroundcolor'];
-$titlefont = $_POST['titlefont'];
-$fontcolor = $_POST['fontcolor'];
-$fontbold = $_POST['fontbold'];
-$fontitalic = $_POST['fontitalic'];
-$fontunderline = $_POST['fontunderline'];
-$artistbgr = $_POST['artbackground'];
-$leftbar = $_POST['leftbar'];
-$rightbar = $_POST['rightbar'];
-$labeltype = $_POST['labeltype'];
-$prelabel = $_POST['prelabel'];
-$artistBoxStyle = $_POST['artistBoxStyle'];
-
-if ($artistBoxStyle == "") {
-    $artistBoxStyle = 'arrows';
-}
-
-if(isset($_POST['artist_upper']) && $_POST['artist_upper'] == 'artist_upper_case') {
-    $artist_upper_case = true;
-}
-else {
-    $artist_upper_case = false;
-}
-
-if(isset($_POST['track_upper']) && $_POST['track_upper'] == 'track_upper_case') {
-    $track_upper_case = true;
-}
-else {
-    $track_upper_case = false;
-}
-
-$font_style = $fontbold . $fontitalic . $fontunderline;
 //
 // start building pdf
 $pdf = new SsFpdfExtended('P', 'pt', 'Letter'); // Imported from cellz.php containing an extended version of FPDF
@@ -77,7 +39,7 @@ $pdf->SetLeftMargin(18);
 $pdf->SetTopMargin(18);
 $pdf->AddPage();
 
-switch ($titlesize) {
+switch ($ts_manager->titlesize) {
     case "small":
         $fontsize = $smallfontsize;
         break;
@@ -92,7 +54,7 @@ switch ($titlesize) {
 // #################################################
 // START SET The LINE color Routine
 // #################################################
-$a = hex2rgb($framecolor);
+$a = hex2rgb($ts_manager->framecolor);
 $stripr = $a[0];
 $stripg = $a[1];
 $stripb = $a[2];
@@ -100,7 +62,7 @@ $stripb = $a[2];
 // #########################################
 // Start set the background COLOR ROUTINE
 // #########################################
-$a = hex2rgb($backgroundcolor);
+$a = hex2rgb($ts_manager->backgroundcolor);
 $stripbgr = $a[0];
 $stripbgg = $a[1];
 $stripbgb = $a[2];
@@ -108,15 +70,23 @@ $stripbgb = $a[2];
 // #########################################
 // Start set the artist background COLOR ROUTINE
 // #########################################
-$a = hex2rgb($artistbackgroundcolor);
+$a = hex2rgb($ts_manager->artistbackgroundcolor);
 $artiststripbgr = $a[0];
 $artiststripbgg = $a[1];
 $artiststripbgb = $a[2];
 
+// #########################################
+// Start set the font COLOR ROUTINE
+// #########################################
+$a = hex2rgb($ts_manager->fontcolor);
+$fontcolorr = $a[0];
+$fontcolorg = $a[1];
+$fontcolorb = $a[2];
+
 // ################################################
 // START Paint the frame Background if selected Routine
 // ################################################
-if ($background) {
+if ($ts_manager->background) {
     $pdf->SetLineWidth(6);
     $pdf->SetDrawColor($stripbgr, $stripbgg, $stripbgb);
     $pdf->SetFillColor($stripbgr, $stripbgg, $stripbgb);
@@ -130,7 +100,7 @@ if ($background) {
 // End Paint the Background Routine
 // #########################################
 
-switch ($labeltype) {
+switch ($ts_manager->labeltype) {
     case "text":
 
         // #########################################
@@ -139,8 +109,8 @@ switch ($labeltype) {
         for ($horiz = 0; $horiz <= 1; $horiz ++) {
             // and do it zero to nine times for ten rows
             for ($vert = 0; $vert <= 9; $vert ++) {
-                $pdf->SetFont($titlefont, $font_style, $fontsize);
-                if ($prelabel == "") {
+                $pdf->SetFont($ts_manager->titlefont, $ts_manager->font_style, $fontsize);
+                if ($ts_manager->prelabel == "") {
                     // ###########################################################
                     // START Print the top and bottom lines of the labels Routine
                     // ###########################################################
@@ -151,7 +121,6 @@ switch ($labeltype) {
                         $pdf->Line(18 + $horiz * 288, 22 + $vert * 72, 234 + $horiz * 288, 22 + $vert * 72);
                     }
                     $pdf->Line(18 + $horiz * 288, 90 + $vert * 72, 234 + $horiz * 288, 90 + $vert * 72);
-
                     // #########################################
                     // End Top and Bottom Line Routine
                     // #########################################
@@ -177,7 +146,7 @@ switch ($labeltype) {
                     $ab_draw_box = True;
                     $ab_draw_hex = False;
 
-                    switch ($artistBoxStyle) {
+                    switch ($ts_manager->artistBoxStyle) {
                         case "arrows":
                             $ab_draw_arrows = True;
                             $ab_draw_box = True;
@@ -199,15 +168,14 @@ switch ($labeltype) {
                     $pdf->SetLineWidth(1);
 
                     if ($ab_draw_box) {
-                        if ($artistbgr) {
+                        if ($ts_manager->artistbgr) {
                             $pdf->SetFillColor($artiststripbgr, $artiststripbgg, $artiststripbgb);
-                            $pdf->SetDrawColor($stripr, $stripg, $stripb);
-                            $pdf->Rect(39 + $horiz * 288, 45 + $vert * 72, 168, 18, 'DF');
                         } else {
                             $pdf->SetFillColor(255, 255, 255);//blank fill
-                            $pdf->SetDrawColor($stripr, $stripg, $stripb);
-                            $pdf->Rect(39 + $horiz * 288, 45 + $vert * 72, 168, 18, 'DF');
                         }
+                        $pdf->SetDrawColor($stripr, $stripg, $stripb);
+                        $pdf->Rect(39 + $horiz * 288, 45 + $vert * 72, 168, 18, 'DF');
+
 
                         // ##############################################
                         // START PLACE BARS ON SIDE OF ARTIST BOX ROUTINE
@@ -325,12 +293,12 @@ switch ($labeltype) {
                 $combinedartist = $ts_manager->titlestrips[$recordtoprint]->get_combined_artist();
                 $publisherinfo = $ts_manager->titlestrips[$recordtoprint]->get_combined_publisherinfo();
 
-                if ($track_upper_case) {
+                if ($ts_manager->track_upper_case) {
                     $track_a = strtoupper($track_a);
                     $track_b = strtoupper($track_b);
                 }
 
-                if ($artist_upper_case) {
+                if ($ts_manager->artist_upper_case) {
                     $combinedartist = strtoupper($combinedartist);
                 }
 
@@ -338,10 +306,6 @@ switch ($labeltype) {
                 // START Change Font Color Routine
                 // #########################################
 
-                $a = hex2rgb($fontcolor);
-                $fontcolorr = $a[0];
-                $fontcolorg = $a[1];
-                $fontcolorb = $a[2];
                 $pdf->SetTextColor($fontcolorr, $fontcolorg, $fontcolorb);
 
                 // #########################################
@@ -411,8 +375,8 @@ switch ($labeltype) {
         for ($horiz = 0; $horiz <= 1; $horiz ++) {
             // and do it nine times for ten rows
             for ($vert = 0; $vert <= 9; $vert ++) {
-                $pdf->SetFont($titlefont, $font_style, $fontsize);
-                if ($prelabel == "") {
+                $pdf->SetFont($ts_manager->titlefont, $font_style, $fontsize);
+                if ($ts_manager->prelabel == "") {
                     // ###########################################################
                     // START Print the top and bottom lines of the labels Routine
                     // ###########################################################
@@ -447,16 +411,14 @@ switch ($labeltype) {
                     // START Make the Box for the Artist Routine
                     // #########################################
                     $pdf->SetLineWidth(1);
-                    if ($artistbgr) {
+                    if ($ts_manager->artistbgr) {
                         $pdf->SetFillColor($artiststripbgr, $artiststripbgg, $artiststripbgb);
-                        $pdf->SetDrawColor($stripr, $stripg, $stripb);
-                        $pdf->Rect(82 + $horiz * 288, 45 + $vert * 72, 154, 18, 'DF');
-                        $pdf->SetDrawColor($stripr, $stripg, $stripb);
                     } else {
-                        $pdf->SetFillColor(255, 255, 255);
-                        $pdf->SetDrawColor($stripr, $stripg, $stripb);
-                        $pdf->Rect(82 + $horiz * 288, 45 + $vert * 72, 154, 18, 'DF');
+                        $pdf->SetFillColor(255, 255, 255); // whiite/blank
                     }
+                    $pdf->SetDrawColor($stripr, $stripg, $stripb);
+                    $pdf->Rect(82 + $horiz * 288, 45 + $vert * 72, 154, 18, 'DF');
+
                     // #########################################
                     // End Make Box for Artist Routine
                     // #########################################
@@ -478,23 +440,18 @@ switch ($labeltype) {
                 $combinedartist = $ts_manager->titlestrips[$recordtoprint]->get_combined_artist();
                 $publisherinfo = $ts_manager->titlestrips[$recordtoprint]->get_combined_publisherinfo();
 
-                if ($track_upper_case) {
+                if ($ts_manager->track_upper_case) {
                     $track_a = strtoupper($track_a);
                     $track_b = strtoupper($track_b);
                 }
 
-                if ($artist_upper_case) {
+                if ($ts_manager->artist_upper_case) {
                     $combinedartist = strtoupper($combinedartist);
                 }
 
                 // #########################################
                 // START Change Font Color Routine
                 // #########################################
-
-                $a = hex2rgb($fontcolor);
-                $fontcolorr = $a[0];
-                $fontcolorg = $a[1];
-                $fontcolorb = $a[2];
                 $pdf->SetTextColor($fontcolorr, $fontcolorg, $fontcolorb);
 
                 // #########################################

--- a/printstrips.php
+++ b/printstrips.php
@@ -69,7 +69,7 @@ else {
 $font_style = $fontbold . $fontitalic . $fontunderline;
 //
 // start building pdf
-$pdf = new ZPDF('P', 'pt', 'Letter');
+$pdf = new SsFpdfExtended('P', 'pt', 'Letter'); // Imported from cellz.php containing an extended version of ZPDF
 $pdftitle = 'Jukebox Title Strips';
 $author = 'Simple Stripper Version 1.10 Modified by David Roman-Halliday';
 

--- a/printstrips.php
+++ b/printstrips.php
@@ -11,18 +11,23 @@
 // Originally written by George Howell
 
 // get some bookkeeping out of the way
-// This is Version 1.10 (still backwards compatible)
+// This is Version 3.1 (still mostly backwards compatible with inputs)
 
 define('FPDF_FONTPATH', 'fpdf/font/');
 require "fpdf/fpdf.php";
 require "cellz.php";
+
+require "titlestrip.php";
+
 $publisherfont = "Helvetica";
 $largefontsize = "16";
 $mediumfontsize = "12";
 $smallfontsize = "9";
 
-// define variables no longer global per Stephen Rice
-// *******************
+// Get variables from POST and populate titlestrip objects
+$ts_manager = new titlestrip_manager;
+
+// Non array values
 $titlesize = $_POST['titlesize'];
 $titlefont = $_POST['titlefont'];
 $framecolor = $_POST['framecolor'];
@@ -30,12 +35,6 @@ $background = $_POST['background'];
 $backgroundcolor = $_POST['backgroundcolor'];
 $artistbackgroundcolor = $_POST['artistbackgroundcolor'];
 $titlefont = $_POST['titlefont'];
-$titlea = $_POST['titlea'];
-$titleb = $_POST['titleb'];
-$artista = $_POST['artista'];
-$artistb = $_POST['artistb'];
-$publisher = $_POST['publisher'];
-$publisherid = $_POST['publisherid'];
 $fontcolor = $_POST['fontcolor'];
 $fontbold = $_POST['fontbold'];
 $fontitalic = $_POST['fontitalic'];
@@ -45,7 +44,6 @@ $leftbar = $_POST['leftbar'];
 $rightbar = $_POST['rightbar'];
 $labeltype = $_POST['labeltype'];
 $prelabel = $_POST['prelabel'];
-$imagename = $_POST['imagename'];
 $artistBoxStyle = $_POST['artistBoxStyle'];
 
 if ($artistBoxStyle == "") {
@@ -69,9 +67,9 @@ else {
 $font_style = $fontbold . $fontitalic . $fontunderline;
 //
 // start building pdf
-$pdf = new SsFpdfExtended('P', 'pt', 'Letter'); // Imported from cellz.php containing an extended version of ZPDF
+$pdf = new SsFpdfExtended('P', 'pt', 'Letter'); // Imported from cellz.php containing an extended version of FPDF
 $pdftitle = 'Jukebox Title Strips';
-$author = 'Simple Stripper Version 1.10 Modified by David Roman-Halliday';
+$author = 'Simple Stripper Version 3.1 Modified by David Roman-Halliday';
 
 $pdf->SetTitle($pdftitle);
 $pdf->SetAuthor($author);
@@ -311,8 +309,30 @@ switch ($labeltype) {
 
                 } // end if prelabe
 
+                // ####################################################
                 // next line picks which record to print based on which cell we are working on
+                // ####################################################
                 $recordtoprint = (($horiz * 10) + $vert + 1);
+
+                // ####################################################
+                // Get text properties from strip
+                // Including: combine artist a and b into one string if needed
+                // ####################################################
+                $track_a = $ts_manager->titlestrips[$recordtoprint]->track_a;
+                $track_b = $ts_manager->titlestrips[$recordtoprint]->track_b;
+                $leftbar = $ts_manager->titlestrips[$recordtoprint]->left_bar;
+                $rightbar = $ts_manager->titlestrips[$recordtoprint]->right_bar;
+                $combinedartist = $ts_manager->titlestrips[$recordtoprint]->get_combined_artist();
+                $publisherinfo = $ts_manager->titlestrips[$recordtoprint]->get_combined_publisherinfo();
+
+                if ($track_upper_case) {
+                    $track_a = strtoupper($track_a);
+                    $track_b = strtoupper($track_b);
+                }
+
+                if ($artist_upper_case) {
+                    $combinedartist = strtoupper($combinedartist);
+                }
 
                 // #########################################
                 // START Change Font Color Routine
@@ -332,21 +352,13 @@ switch ($labeltype) {
                 // /Start Print The Titles
                 // ####################################################
 
-                // next lines sets top left corner of box. Extra y offset to get off
-                // of lines. line after that prints title of a side
+                // set position (top left coordinates) and print title of A side
                 $pdf->SetXY(18 + $horiz * 288, 34 + $vert * 72);
-                $titlea[$recordtoprint] = stripslashes($titlea[$recordtoprint]);
-                if ($track_upper_case) {
-                    $titlea[$recordtoprint] = strtoupper($titlea[$recordtoprint]);
-                }
-                $pdf->CellZ(212, 0, $titlea[$recordtoprint], '', '', 'C');
-                // set position and print title of b side
+                $pdf->CellZ(212, 0, $track_a, '', '', 'C');
+
+                // set position (top left coordinates) and print title of B side
                 $pdf->SetXY(18 + $horiz * 288, 73 + $vert * 72);
-                $titleb[$recordtoprint] = stripslashes($titleb[$recordtoprint]);
-                if ($track_upper_case) {
-                    $titleb[$recordtoprint] = strtoupper($titleb[$recordtoprint]);
-                }
-                $pdf->CellZ(212, 0, $titleb[$recordtoprint], '', '', 'C');
+                $pdf->CellZ(212, 0, $track_b, '', '', 'C');
 
                 // ####################################################
                 // /End Print The Titles
@@ -355,18 +367,10 @@ switch ($labeltype) {
                 // ####################################################
                 // /Start Print The Artists, Publisher and Publisher ID
                 // ####################################################
-                // combine artist a and b into one string if needed
-
-                $combinedartist = get_combined_artist($recordtoprint);
-
-                if ($artist_upper_case) {
-                    $combinedartist = strtoupper($combinedartist);
-                }
 
                 $pdf->SetXY(44 + $horiz * 288, 54 + $vert * 72);
                 $pdf->CellZ(156, 0, $combinedartist, '', '', 'C');
-                $publisherinfo = "$publisher[$recordtoprint] $publisherid[$recordtoprint]";
-                $publisherinfo = stripslashes($publisherinfo);
+
                 $pdf->SetFont('Helvetica', '', 6);
                 $pdf->SetXY(174 + $horiz * 288, 86 + $vert * 72);
                 $pdf->CellZ(60, 0, $publisherinfo, '', '', 'L');
@@ -377,13 +381,15 @@ switch ($labeltype) {
 
                 // Set text color to white (transparent on paper)
                 $pdf->SetTextColor(255, 255, 255);
+
                 // next lines sets top left corner of box. Extra y offset to get off
                 // of lines. line after that prints left bar content
                 $pdf->SetXY(18 + $horiz * 288, 54 + $vert * 72);
-                $pdf->CellZ(20, 0, $leftbar[$recordtoprint], '', '', 'C');
+                $pdf->CellZ(20, 0, $leftbar, '', '', 'C');
+
                 // Do the same with the right
                 $pdf->SetXY(208 + $horiz * 288, 54 + $vert * 72);
-                $pdf->CellZ(20, 0, $rightbar[$recordtoprint], '', '', 'C');
+                $pdf->CellZ(20, 0, $rightbar, '', '', 'C');
 
                 // ##############################################
                 // END Print the Type and hit if wanted
@@ -456,6 +462,31 @@ switch ($labeltype) {
                     // #########################################
                 } // End if prelabel
 
+                // ####################################################
+                // Get text properties from strip
+                // Including: combine artist a and b into one string if needed
+                // ####################################################
+
+
+                // next line picks which record to print based on which cell we are working on
+                $recordtoprint = (($horiz * 10) + $vert + 1);
+
+                $track_a = $ts_manager->titlestrips[$recordtoprint]->track_a;
+                $track_b = $ts_manager->titlestrips[$recordtoprint]->track_b;
+                $leftbar = $ts_manager->titlestrips[$recordtoprint]->left_bar;
+                $rightbar = $ts_manager->titlestrips[$recordtoprint]->right_bar;
+                $combinedartist = $ts_manager->titlestrips[$recordtoprint]->get_combined_artist();
+                $publisherinfo = $ts_manager->titlestrips[$recordtoprint]->get_combined_publisherinfo();
+
+                if ($track_upper_case) {
+                    $track_a = strtoupper($track_a);
+                    $track_b = strtoupper($track_b);
+                }
+
+                if ($artist_upper_case) {
+                    $combinedartist = strtoupper($combinedartist);
+                }
+
                 // #########################################
                 // START Change Font Color Routine
                 // #########################################
@@ -470,16 +501,31 @@ switch ($labeltype) {
                 // END Font Color Routine
                 // #########################################
 
-                // next line picks which record to print based on which cell we are working on
-                $recordtoprint = (($horiz * 10) + $vert + 1);
 
                 // #########################################################
                 // Print A IMAGE ON THE LABEL ROUTINE.
                 // #########################################################
 
-                if ($imagename[$recordtoprint] > "") {
-                    $pdf->Image($imagename[$recordtoprint], 16.8 + $horiz * 288, 23.2 + $vert * 72, 0, 65);
-                } else {}
+                if (    isset($ts_manager->titlestrips[$recordtoprint]->image_reference)
+                    and strlen($ts_manager->titlestrips[$recordtoprint]->image_reference) > 0
+                   )
+                {
+                    if ($ts_manager->titlestrips[$recordtoprint]->image_refernce_is_url()) {
+                        // Download file and put into PDF
+                        $ts_manager->titlestrips[$recordtoprint]->download_and_store_url_image_file();
+
+                        // Put temp file into PDF
+                        $image_file = $ts_manager->titlestrips[$recordtoprint]->image_file_reference;
+                        $pdf->Image($image_file, 16.8 + $horiz * 288, 23.2 + $vert * 72, 0, 65);
+
+                        // Delete temp file downloaded
+                        $ts_manager->titlestrips[$recordtoprint]->delete_local_image_file();
+                    } else {
+                        // Put existing file into PDF
+                        $image_file = $ts_manager->titlestrips[$recordtoprint]->image_file_reference;
+                        $pdf->Image($image_file, 16.8 + $horiz * 288, 23.2 + $vert * 72, 0, 65);
+                    }
+                }
 
                 // #########################################################
                 // Print THE TITLES OF THE RECORDS ROUTINE.
@@ -487,35 +533,21 @@ switch ($labeltype) {
                 // of lines. line after that prints title of a side
                 // #########################################################
 
+                // set position (top left coordinates) and print title of A side
                 $pdf->SetXY(84 + $horiz * 288, 34 + $vert * 72);
-                $titlea[$recordtoprint] = stripslashes($titlea[$recordtoprint]);
-                if ($track_upper_case) {
-                    $titlea[$recordtoprint] = strtoupper($titlea[$recordtoprint]);
-                }
-                $pdf->CellZ(148, 0, $titlea[$recordtoprint], '', '', 'C');
-                // set position and print title of b side
+                $pdf->CellZ(148, 0, $track_a, '', '', 'C');
+
+                // set position (top left coordinates) and print title of B side
                 $pdf->SetXY(84 + $horiz * 288, 73 + $vert * 72);
-                $titleb[$recordtoprint] = stripslashes($titleb[$recordtoprint]);
-                if ($track_upper_case) {
-                    $titleb[$recordtoprint] = strtoupper($titleb[$recordtoprint]);
-                }
-                $pdf->CellZ(148, 0, $titleb[$recordtoprint], '', '', 'C');
+                $pdf->CellZ(148, 0, $track_b, '', '', 'C');
 
                 // ####################################################
                 // /Start Print The Artists, Publisher and Publisher ID
                 // ####################################################
-                // combine artist a and b into one string if needed
-
-                $combinedartist = get_combined_artist($recordtoprint);
-
-                if ($artist_upper_case) {
-                    $combinedartist = strtoupper($combinedartist);
-                }
 
                 $pdf->SetXY(84 + $horiz * 288, 54 + $vert * 72);
                 $pdf->CellZ(148, 0, $combinedartist, '', '', 'C');
-                $publisherinfo = "$publisher[$recordtoprint] $publisherid[$recordtoprint]";
-                $publisherinfo = stripslashes($publisherinfo);
+
                 $pdf->SetFont('Helvetica', '', 6);
                 $pdf->SetXY(174 + $horiz * 288, 86 + $vert * 72);
                 $pdf->CellZ(60, 0, $publisherinfo, '', '', 'L');
@@ -529,51 +561,4 @@ switch ($labeltype) {
 // we're done. Send it out
 $pdf->Output('titlestrips.pdf', 'I');
 
-function get_combined_artist($array_pos)
-{
-    //To make this properly work across all code, there should be a class titlestrip() and an array of them.
-    $artista = $_POST['artista'];
-    $artistb = $_POST['artistb'];
-
-    $this_artist_a = trim(stripslashes($artista[$array_pos]));
-    $this_artist_b = trim(stripslashes($artistb[$array_pos]));
-
-    if (strlen($this_artist_a) > 0 && strlen($this_artist_b) > 0) {
-        if ($this_artist_a == $this_artist_b) {
-            $combinedartist = $this_artist_a;
-        } else {
-            $combinedartist = "$this_artist_a/$this_artist_b";
-        }
-    } elseif (strlen($this_artist_a) > 0) {
-        $combinedartist = "$this_artist_a";
-    } elseif (strlen($this_artist_b) > 0) {
-        $combinedartist = "$this_artist_b";
-    } else {
-        $combinedartist = "";
-    }
-
-    return stripslashes($combinedartist);
-
-}
-
-function &hex2rgb($hex, $asString = true)
-{
-    // strip off any leading #
-    if (0 === strpos($hex, '#')) {
-        $hex = substr($hex, 1);
-    } else if (0 === strpos($hex, '&H')) {
-        $hex = substr($hex, 2);
-    }
-
-    // break into hex 3-tuple
-    $cutpoint = ceil(strlen($hex) / 2) - 1;
-    $rgb = explode(':', wordwrap($hex, $cutpoint, ':', $cutpoint), 3);
-
-    // convert each tuple to decimal
-    $rgb[0] = (isset($rgb[0]) ? hexdec($rgb[0]) : 0);
-    $rgb[1] = (isset($rgb[1]) ? hexdec($rgb[1]) : 0);
-    $rgb[2] = (isset($rgb[2]) ? hexdec($rgb[2]) : 0);
-
-    return $rgb; // ($asString ? "{$rgb[0]} {$rgb[1]} {$rgb[2]}" : $rgb);
-}
 ?>

--- a/titlestrip.php
+++ b/titlestrip.php
@@ -1,0 +1,251 @@
+<?php
+
+class titlestrip {
+
+    // Variables populated by the form fields
+    public $track_a;
+    public $track_b;
+    public $artist_a;
+    public $artist_b;
+    public $left_bar;
+    public $right_bar;
+    public $publisher;
+    public $publisher_id;
+    public $image_reference;
+
+    // Variables used for control and management
+    public $image_file_reference;
+    protected $image_file_is_temporary = False;
+
+    function get_combined_artist() {
+        if (strlen($this->artist_a) > 0 && strlen($this->artist_b) > 0) {
+            if ($this->artist_a == $this->artist_b) {
+                $combinedartist = $this->artist_a;
+            } else {
+                $combinedartist = "$this->artist_a/$this->artist_b";
+            }
+        } elseif (strlen($this->artist_a) > 0) {
+            $combinedartist = "$this->artist_a";
+        } elseif (strlen($this->artist_b) > 0) {
+            $combinedartist = "$this->artist_b";
+        } else {
+            $combinedartist = "";
+        }
+
+        return trim($combinedartist);
+
+    }
+
+    function get_combined_publisherinfo() {
+        $combined_publisherinfo = "$this->publisher $this->publisher_id";
+        return trim($combined_publisherinfo);
+    }
+
+    function has_set_values() {
+        $result = False;
+        if (   (isset($this->track_a)         and strlen($this->track_a)         > 0)
+            or (isset($this->track_b)         and strlen($this->track_b)         > 0)
+            or (isset($this->artist_a)        and strlen($this->artist_a)        > 0)
+            or (isset($this->artist_b)        and strlen($this->artist_b)        > 0)
+            or (isset($this->left_bar)        and strlen($this->left_bar)        > 0)
+            or (isset($this->right_bar)       and strlen($this->right_bar)       > 0)
+            or (isset($this->publisher)       and strlen($this->publisher)       > 0)
+            or (isset($this->publisher_id)    and strlen($this->publisher_id)    > 0)
+            or (isset($this->image_reference) and strlen($this->image_reference) > 0)
+           )
+        {
+            $result = True;
+        }
+        return $result;
+    }
+
+    function image_refernce_is_url() {
+
+        $result = False;
+
+        if(filter_var($this->image_reference, FILTER_VALIDATE_URL))
+        {
+            //ToDo: Any extra validation e.g. domains here
+            $result = True;
+        }
+
+        return $result;
+    }
+
+    function is_valid_image_file_type($image_filename_to_check) {
+        $result = False;
+        $valid_file_types = ['jpg','png','gif'];
+        $image_file_type = pathinfo($image_filename_to_check, PATHINFO_EXTENSION); // to get extension
+
+        if (in_array($image_file_type, $valid_file_types)) {
+            $result = True;
+        } else {
+            $result = False;
+        }
+
+        return $result;
+    }
+
+    function delete_local_image_file() {
+        if (!$this->image_file_is_temporary) {
+            throw new Exception('Not deleting a non-temp image');
+        } else {
+            $file_pointer = $this->image_file_reference;
+
+            // Only try to delete a file if it exists
+            if (!file_exists($file_pointer)) {
+                throw new Exception('File not exists/already deleted: '.$file_pointer);
+            }
+
+            // Use unlink() function to delete a file (it returns false on error)
+            if (!unlink($file_pointer)) {
+                //echo ("$file_pointer cannot be deleted due to an error");
+                throw new Exception('Failed to delete file: '.$file_pointer);
+            }
+
+            // Check we were succesful
+            if (file_exists($file_pointer)) {
+                throw new Exception('File not deleted: '.$file_pointer);
+            }
+        }
+    }
+
+    function set_image_file_reference() {
+        if (    !$this->image_refernce_is_url()
+            and file_exists($this->image_reference) // It's not a URL and it's one of our existing local files
+           )
+        {
+            if (!$this->is_valid_image_file_type($this->image_reference)) {
+                throw new Exception('Invalid image file type: '.$this->image_reference);
+            } else {
+                if (file_exists($this->image_reference)) {
+                    $this->image_file_reference = $this->image_reference;
+                } else {
+                    throw new Exception('File doesn\'t exist: '.$this->image_reference);
+                }
+
+                $this->image_file_is_temporary = False;
+            }
+        } else { // It's a URL and we want to download and create it localy
+            $url_file_path = parse_url($this->image_reference, PHP_URL_PATH); // This trims anything off the end of the filename (like HTML arguments)
+            $url_file_name = basename($url_file_path); // to get just the file name
+            $unique_id = uniqid();
+            $local_file_name = 'temp-image_'.$unique_id.'_'.$url_file_name;
+
+            if (!$this->is_valid_image_file_type($url_file_name)) {
+                throw new Exception('Invalid image file type in URL: '.$url_file_name);
+            }
+
+            $this->image_file_reference = "images/$local_file_name";
+            $this->image_file_is_temporary = True;
+
+            if (file_exists($this->image_file_reference)) {
+                throw new Exception('File already exists: '.$this->image_file_reference);
+            }
+        }
+    }
+
+    function download_and_store_url_image_file() {
+        // Test to make sure it's not already there
+        if (file_exists($this->image_file_reference)) {
+            throw new Exception('This File already exists: '.$this->image_file_reference);
+        }
+
+        // Download and store file localy
+        $ch = curl_init($this->image_reference);
+        $fp = fopen($this->image_file_reference, 'wb');
+        curl_setopt($ch, CURLOPT_FILE, $fp);
+        curl_setopt($ch, CURLOPT_HEADER, 0);
+        curl_exec($ch);
+        curl_close($ch);
+        fclose($fp);
+
+        // Test its there
+        if (!file_exists($this->image_file_reference)) {
+            throw new Exception('Failed to create image file: '.$this->image_file_reference);
+        }
+    }
+}
+
+class titlestrip_manager {
+
+    protected $post_array_title_a;
+    protected $post_array_title_b;
+    protected $post_array_artist_a;
+    protected $post_array_artist_b;
+    protected $post_array_left_bar;
+    protected $post_array_right_bar;
+    protected $post_array_publisher;
+    protected $post_array_publisher_id;
+    protected $post_array_image_reference;
+
+    public $titlestrips = array();
+
+    function __construct(){
+        if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+            $this->populate_post_variables();
+            $this->populate_titlestrips();
+        }
+    }
+
+    protected function populate_post_variables(){
+        $this->post_array_title_a = $_POST['titlea'];
+        $this->post_array_title_b = $_POST['titleb'];
+        $this->post_array_artist_a = $_POST['artista'];
+        $this->post_array_artist_b = $_POST['artistb'];
+        $this->post_array_left_bar = $_POST['leftbar'];
+        $this->post_array_right_bar = $_POST['rightbar'];
+        $this->post_array_publisher = $_POST['publisher'];
+        $this->post_array_publisher_id = $_POST['publisherid'];
+        $this->post_array_image_reference = $_POST['imagename'];
+    }
+
+    function populate_titlestrips(){
+        for ($i = 1; $i <= 20; $i ++) {
+            $this->titlestrips[$i] = new titlestrip();
+            $this->titlestrips[$i]->track_a = trim(stripslashes($this->post_array_title_a[$i]));
+            $this->titlestrips[$i]->track_b = trim(stripslashes($this->post_array_title_b[$i]));
+            $this->titlestrips[$i]->artist_a = trim(stripslashes($this->post_array_artist_a[$i]));
+            $this->titlestrips[$i]->artist_b = trim(stripslashes($this->post_array_artist_b[$i]));
+            $this->titlestrips[$i]->left_bar = trim(stripslashes($this->post_array_left_bar[$i]));
+            $this->titlestrips[$i]->right_bar = trim(stripslashes($this->post_array_right_bar[$i]));
+            $this->titlestrips[$i]->publisher = trim(stripslashes($this->post_array_publisher[$i]));
+            $this->titlestrips[$i]->publisher_id = trim(stripslashes($this->post_array_publisher_id[$i]));
+            $this->titlestrips[$i]->image_reference = trim(stripslashes($this->post_array_image_reference[$i]));
+
+            if (    isset($this->titlestrips[$i]->image_reference)
+                and strlen($this->titlestrips[$i]->image_reference) > 0
+               )
+            {
+                //$check_message = 'Setting Image: '.$this->titlestrips[$i]->image_reference;
+                //error_log(print_r($check_message, TRUE));
+
+                $this->titlestrips[$i]->set_image_file_reference();
+            }
+        }
+    }
+
+}
+
+function &hex2rgb($hex, $asString = true)
+{
+    // strip off any leading #
+    if (0 === strpos($hex, '#')) {
+        $hex = substr($hex, 1);
+    } else if (0 === strpos($hex, '&H')) {
+        $hex = substr($hex, 2);
+    }
+
+    // break into hex 3-tuple
+    $cutpoint = ceil(strlen($hex) / 2) - 1;
+    $rgb = explode(':', wordwrap($hex, $cutpoint, ':', $cutpoint), 3);
+
+    // convert each tuple to decimal
+    $rgb[0] = (isset($rgb[0]) ? hexdec($rgb[0]) : 0);
+    $rgb[1] = (isset($rgb[1]) ? hexdec($rgb[1]) : 0);
+    $rgb[2] = (isset($rgb[2]) ? hexdec($rgb[2]) : 0);
+
+    return $rgb; // ($asString ? "{$rgb[0]} {$rgb[1]} {$rgb[2]}" : $rgb);
+}
+
+?>

--- a/titlestrip.php
+++ b/titlestrip.php
@@ -169,6 +169,7 @@ class titlestrip {
 
 class titlestrip_manager {
 
+    // Array Variables (used internaly to allocate to titlestrips array)
     protected $post_array_title_a;
     protected $post_array_title_b;
     protected $post_array_artist_a;
@@ -179,6 +180,29 @@ class titlestrip_manager {
     protected $post_array_publisher_id;
     protected $post_array_image_reference;
 
+    // Non Array Variables
+    public $titlesize;
+    public $titlefont;
+    public $framecolor;
+    public $background;
+    public $backgroundcolor;
+    public $artistbackgroundcolor;
+
+    public $fontcolor;
+    public $fontbold;
+    public $fontitalic;
+    public $fontunderline;
+    public $artistbgr;
+    public $leftbar;
+    public $rightbar;
+    public $labeltype;
+    public $prelabel;
+    public $artistBoxStyle;
+
+    public $artist_upper_case = false;
+    public $track_upper_case = false;
+
+    // Array for title strips
     public $titlestrips = array();
 
     function __construct(){
@@ -189,6 +213,7 @@ class titlestrip_manager {
     }
 
     protected function populate_post_variables(){
+        // Array Variables
         $this->post_array_title_a = $_POST['titlea'];
         $this->post_array_title_b = $_POST['titleb'];
         $this->post_array_artist_a = $_POST['artista'];
@@ -198,6 +223,45 @@ class titlestrip_manager {
         $this->post_array_publisher = $_POST['publisher'];
         $this->post_array_publisher_id = $_POST['publisherid'];
         $this->post_array_image_reference = $_POST['imagename'];
+
+        // Non Array Variables
+        $this->titlesize = $_POST['titlesize'];
+        $this->titlefont = $_POST['titlefont'];
+        $this->framecolor = $_POST['framecolor'];
+        $this->background = $_POST['background'];
+        $this->backgroundcolor = $_POST['backgroundcolor'];
+        $this->artistbackgroundcolor = $_POST['artistbackgroundcolor'];
+
+        // Fonts
+        $this->fontcolor = $_POST['fontcolor'];
+
+        $this->fontbold = $_POST['fontbold'];
+        $this->fontitalic = $_POST['fontitalic'];
+        $this->fontunderline = $_POST['fontunderline'];
+
+        $this->font_style = $this->fontbold . $this->fontitalic . $this->fontunderline;
+
+
+        $this->artistbgr = $_POST['artbackground'];
+        $this->leftbar = $_POST['leftbar'];
+        $this->rightbar = $_POST['rightbar'];
+        $this->labeltype = $_POST['labeltype'];
+        $this->prelabel = $_POST['prelabel'];
+
+        $this->artistBoxStyle = trim(stripslashes($_POST['artistBoxStyle']));
+        #Set default
+        if ($this->artistBoxStyle == "") {
+            $this->artistBoxStyle = 'arrows';
+        }
+
+        if(isset($_POST['artist_upper']) && $_POST['artist_upper'] == 'artist_upper_case') {
+            $this->artist_upper_case = true;
+        }
+
+        if(isset($_POST['track_upper']) && $_POST['track_upper'] == 'track_upper_case') {
+            $this->track_upper_case = true;
+        }
+
     }
 
     function populate_titlestrips(){

--- a/titlestrip.php
+++ b/titlestrip.php
@@ -74,7 +74,7 @@ class titlestrip {
 
     function is_valid_image_file_type($image_filename_to_check) {
         $result = False;
-        $valid_file_types = ['jpg','png','gif'];
+        $valid_file_types = ['jpg','jpeg','png','gif'];
         $image_file_type = pathinfo($image_filename_to_check, PATHINFO_EXTENSION); // to get extension
 
         if (in_array($image_file_type, $valid_file_types)) {


### PR DESCRIPTION
This was pushed for release faster than expected, as the regular site scraping of Discogs had broken (they added a javascriopt check which curl couldn't work with). Now that the API is configured, future changes should be easier.

1. Made more columns with show/hide buttons.
2. Changed the Discogs integration to use proper API
3. Extended the Discogs integration to get more items including release year information (Tried to import album art, but they have blocked the external image links. Tried to get publisher information but old scraping method broke).
4. Technical reworking to split out code into classes, e.g. the submitted form data (reusable in form and strip creation).
5. Lots of behind-the-scenes technical changes and tweaks (these should make future enhancements easier).
6. Some little UI tweaks.